### PR TITLE
feat(relay): show viewers why a stream failed instead of a dead stream

### DIFF
--- a/cmd/tvarr/cmd/serve.go
+++ b/cmd/tvarr/cmd/serve.go
@@ -372,6 +372,16 @@ func runServe(_ *cobra.Command, _ []string) error {
 	).WithLogger(logger).WithProgressService(progressService).
 		WithStreamSourceRepo(streamSourceRepo)
 
+	// Reclaim programs left behind by a source deletion that did not finish.
+	// Deleting a source removes its row first and sweeps the programs behind the
+	// response, so a restart mid-sweep would otherwise strand them: the source is
+	// gone, nothing queries them, and nothing else would ever remove them.
+	go func() {
+		if err := epgService.SweepOrphanedPrograms(context.Background()); err != nil {
+			logger.Warn("failed to sweep orphaned EPG programs on startup", slog.Any("error", err))
+		}
+	}()
+
 	proxyService := service.NewProxyService(
 		proxyRepo,
 		pipelineFactory,

--- a/internal/pipeline/stages/loadprograms/stage_test.go
+++ b/internal/pipeline/stages/loadprograms/stage_test.go
@@ -72,6 +72,10 @@ func (m *mockProgramRepo) DeleteBySourceID(ctx context.Context, sourceID models.
 	return nil
 }
 
+func (m *mockProgramRepo) DeleteOrphaned(ctx context.Context) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockProgramRepo) DeleteStaleBySourceID(ctx context.Context, sourceID models.ULID, olderThan time.Time) (int64, error) {
 	return 0, nil
 }
@@ -498,6 +502,10 @@ func (m *perSourceMockRepo) GetCurrentByChannelID(ctx context.Context, channelID
 
 func (m *perSourceMockRepo) Delete(ctx context.Context, id models.ULID) error {
 	return nil
+}
+
+func (m *perSourceMockRepo) DeleteOrphaned(ctx context.Context) (int64, error) {
+	return 0, nil
 }
 
 func (m *perSourceMockRepo) DeleteBySourceID(ctx context.Context, sourceID models.ULID) error {

--- a/internal/relay/error_slate.go
+++ b/internal/relay/error_slate.go
@@ -1,0 +1,731 @@
+// Package relay provides stream relay functionality including transcoding,
+// connection pooling, and failure handling.
+package relay
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"log/slog"
+	"net"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/basicfont"
+	"golang.org/x/image/font/inconsolata"
+	"golang.org/x/image/math/fixed"
+
+	"github.com/jmylchreest/tvarr/internal/codec"
+)
+
+// StreamErrorKind classifies why a stream cannot be delivered. It maps onto the
+// PlaceholderType values so the same taxonomy drives both the embedded static
+// placeholders and the rendered slates.
+type StreamErrorKind string
+
+const (
+	// StreamErrorUnavailable covers an origin that cannot be reached or read.
+	StreamErrorUnavailable StreamErrorKind = "unavailable"
+	// StreamErrorLimitReached covers provider-side concurrency refusals.
+	StreamErrorLimitReached StreamErrorKind = "limit_reached"
+	// StreamErrorEnded covers an origin that closed the stream cleanly.
+	StreamErrorEnded StreamErrorKind = "ended"
+	// StreamErrorStarting covers the gap before the first origin bytes arrive.
+	StreamErrorStarting StreamErrorKind = "starting"
+)
+
+// PlaceholderType maps the error kind onto the buffer injector's placeholder
+// taxonomy, so a slate can fall back to embedded static content when no encoder
+// exists for the negotiated variant.
+func (k StreamErrorKind) PlaceholderType() PlaceholderType {
+	switch k {
+	case StreamErrorLimitReached:
+		return PlaceholderLimitReached
+	case StreamErrorEnded:
+		return PlaceholderEnded
+	case StreamErrorStarting:
+		return PlaceholderStarting
+	default:
+		return PlaceholderUnavailable
+	}
+}
+
+// StreamError describes a stream failure in terms a viewer can act on. It
+// carries both the machine-readable kind and the two lines rendered onto the
+// slate, so the same value drives logging, the session state and the picture.
+type StreamError struct {
+	// Kind classifies the failure.
+	Kind StreamErrorKind
+	// Headline is the large first line, e.g. "Channel Unavailable".
+	Headline string
+	// Detail is the smaller second line naming the specific cause.
+	Detail string
+	// HTTPStatus is the upstream status when the failure came from a response.
+	HTTPStatus int
+	// Err is the underlying error, if any.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *StreamError) Error() string {
+	if e.HTTPStatus > 0 {
+		return fmt.Sprintf("%s: %s (upstream HTTP %d)", e.Headline, e.Detail, e.HTTPStatus)
+	}
+	return fmt.Sprintf("%s: %s", e.Headline, e.Detail)
+}
+
+// Unwrap exposes the underlying cause to errors.Is and errors.As.
+func (e *StreamError) Unwrap() error { return e.Err }
+
+// CacheKey identifies the rendered slate for this error. Errors that render
+// identically share one encode, so a flapping origin does not re-encode a slate
+// on every retry.
+func (e *StreamError) CacheKey() string {
+	return string(e.Kind) + "\x00" + e.Headline + "\x00" + e.Detail
+}
+
+// NewUpstreamStatusError builds a StreamError from an upstream HTTP status.
+//
+// Xtream-family panels do not use the documented Player API JSON to signal a
+// refusal on the streaming endpoint; they return a bare non-standard status from
+// the nginx layer in front of the panel. 555 and 999 are both in live use and
+// are not defined by HTTP or by the Xtream API, so they are classified here
+// rather than left to a generic 5xx branch. The account is typically fine -- the
+// same credentials keep working against player_api.php -- so the slate says
+// "too many connections" rather than implying the subscription is dead.
+func NewUpstreamStatusError(status int) *StreamError {
+	e := &StreamError{HTTPStatus: status}
+
+	switch {
+	case status == 429, status == 509, status == 555, status == 999:
+		e.Kind = StreamErrorLimitReached
+		e.Headline = "Too Many Connections"
+		e.Detail = fmt.Sprintf("Provider refused the stream (HTTP %d). Another device may be watching.", status)
+
+	case status == 401 || status == 403:
+		e.Kind = StreamErrorUnavailable
+		e.Headline = "Not Authorised"
+		e.Detail = fmt.Sprintf("Provider rejected the credentials (HTTP %d).", status)
+
+	case status == 404 || status == 410:
+		e.Kind = StreamErrorEnded
+		e.Headline = "Channel Not Found"
+		e.Detail = fmt.Sprintf("Provider no longer offers this stream (HTTP %d).", status)
+
+	case status >= 500:
+		e.Kind = StreamErrorUnavailable
+		e.Headline = "Provider Error"
+		e.Detail = fmt.Sprintf("Upstream server returned HTTP %d.", status)
+
+	default:
+		e.Kind = StreamErrorUnavailable
+		e.Headline = "Channel Unavailable"
+		e.Detail = fmt.Sprintf("Upstream returned HTTP %d.", status)
+	}
+
+	return e
+}
+
+// ClassifyStreamError maps an arbitrary pipeline error onto a StreamError. An
+// error that is already a *StreamError passes through unchanged, so a precise
+// classification made at the failure site is never flattened by a later caller.
+func ClassifyStreamError(err error) *StreamError {
+	if err == nil {
+		return nil
+	}
+
+	var se *StreamError
+	if errors.As(err, &se) {
+		return se
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &StreamError{
+			Kind:     StreamErrorEnded,
+			Headline: "Stream Stopped",
+			Detail:   "The session was closed.",
+			Err:      err,
+		}
+	}
+
+	// DNS failure: the provider hostname no longer resolves. Distinguished from a
+	// refused connection because it is almost always a dead or changed provider
+	// domain rather than a transient outage, and the viewer's fix differs.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return &StreamError{
+			Kind:     StreamErrorUnavailable,
+			Headline: "Provider Not Found",
+			Detail:   fmt.Sprintf("Cannot resolve %s.", dnsErr.Name),
+			Err:      err,
+		}
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &StreamError{
+			Kind:     StreamErrorUnavailable,
+			Headline: "Provider Timed Out",
+			Detail:   "The upstream server did not respond in time.",
+			Err:      err,
+		}
+	}
+
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "connection refused"):
+		return &StreamError{
+			Kind:     StreamErrorUnavailable,
+			Headline: "Connection Refused",
+			Detail:   "The upstream server refused the connection.",
+			Err:      err,
+		}
+	case strings.Contains(msg, "connection reset"):
+		return &StreamError{
+			Kind:     StreamErrorUnavailable,
+			Headline: "Connection Dropped",
+			Detail:   "The upstream server closed the connection.",
+			Err:      err,
+		}
+	case strings.Contains(msg, "no daemon") || strings.Contains(msg, "no available daemon"):
+		return &StreamError{
+			Kind:     StreamErrorUnavailable,
+			Headline: "Transcoder Unavailable",
+			Detail:   "No transcoding capacity is currently available.",
+			Err:      err,
+		}
+	}
+
+	return &StreamError{
+		Kind:     StreamErrorUnavailable,
+		Headline: "Channel Unavailable",
+		Detail:   "The stream could not be started.",
+		Err:      err,
+	}
+}
+
+// ErrorSlateConfig configures slate rendering and encoding.
+type ErrorSlateConfig struct {
+	// Width and Height of the rendered slate. These must match the resolution
+	// already advertised by the variant's init data when injecting mid-stream,
+	// or decoders will reject the samples.
+	Width  int
+	Height int
+	// FrameRate of the encoded slate. A still image needs very few frames per
+	// second; this is kept low deliberately because every frame is piped to
+	// FFmpeg uncompressed.
+	FrameRate int
+	// Duration in seconds of one encoded loop.
+	Duration float64
+	// VideoBitrate in kbps.
+	VideoBitrate int
+	// FFmpegPath is the ffmpeg binary to shell out to.
+	FFmpegPath string
+	// Timeout bounds a single encode.
+	Timeout time.Duration
+	// Scale is the integer upscale applied to the bitmap font. Glyphs are
+	// nearest-neighbour scaled so they stay crisp rather than blurred.
+	Scale int
+}
+
+// DefaultErrorSlateConfig returns defaults sized for a 720p slate.
+func DefaultErrorSlateConfig() ErrorSlateConfig {
+	return ErrorSlateConfig{
+		Width:        1280,
+		Height:       720,
+		FrameRate:    10,
+		Duration:     2.0,
+		VideoBitrate: 800,
+		FFmpegPath:   "ffmpeg",
+		Timeout:      30 * time.Second,
+		Scale:        3,
+	}
+}
+
+// ErrGeneratorNoEncoder is returned when the negotiated variant has no software
+// encoder in this FFmpeg build, so no slate can be rendered for it.
+var ErrGeneratorNoEncoder = errors.New("no software encoder for variant")
+
+// ErrorSlateGenerator renders StreamErrors to ES samples for a codec variant.
+//
+// Text is rasterised in Go and piped to FFmpeg as raw frames rather than drawn
+// with the drawtext filter: the ffmpeg build shipped in the tvarr image is
+// compiled without libfreetype, so drawtext does not exist in it, and the image
+// carries no fonts at all. Rasterising here also keeps the slate identical
+// across every deployment regardless of what fontconfig would have found.
+type ErrorSlateGenerator struct {
+	config   ErrorSlateConfig
+	injector *BufferInjector
+	logger   *slog.Logger
+
+	mu    sync.RWMutex
+	cache map[string]*CachedPlaceholder
+}
+
+// NewErrorSlateGenerator creates a slate generator.
+func NewErrorSlateGenerator(config ErrorSlateConfig, logger *slog.Logger) *ErrorSlateGenerator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if config.Width <= 0 || config.Height <= 0 {
+		d := DefaultErrorSlateConfig()
+		config.Width, config.Height = d.Width, d.Height
+	}
+	if config.FrameRate <= 0 {
+		config.FrameRate = DefaultErrorSlateConfig().FrameRate
+	}
+	if config.Duration <= 0 {
+		config.Duration = DefaultErrorSlateConfig().Duration
+	}
+	if config.FFmpegPath == "" {
+		config.FFmpegPath = "ffmpeg"
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = DefaultErrorSlateConfig().Timeout
+	}
+	if config.Scale <= 0 {
+		config.Scale = DefaultErrorSlateConfig().Scale
+	}
+
+	return &ErrorSlateGenerator{
+		config:   config,
+		injector: GetBufferInjector(),
+		logger:   logger,
+		cache:    make(map[string]*CachedPlaceholder),
+	}
+}
+
+// cacheKey combines the variant and the error, since the same message must be
+// encoded once per codec variant.
+func (g *ErrorSlateGenerator) cacheKey(variant CodecVariant, se *StreamError) string {
+	return string(variant) + "\x00" + se.CacheKey()
+}
+
+// Slate returns ES samples rendering the error for the variant, encoding on
+// first use and serving from cache afterwards.
+func (g *ErrorSlateGenerator) Slate(ctx context.Context, variant CodecVariant, se *StreamError) (*CachedPlaceholder, error) {
+	if se == nil {
+		return nil, errors.New("nil stream error")
+	}
+
+	key := g.cacheKey(variant, se)
+
+	g.mu.RLock()
+	cached, ok := g.cache[key]
+	g.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Double-check under the write lock: two sessions can fail concurrently.
+	if cached, ok := g.cache[key]; ok {
+		return cached, nil
+	}
+
+	start := time.Now()
+
+	data, err := g.encode(ctx, variant, se)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reuse the buffer injector's fMP4 demuxer so slates and the embedded
+	// placeholders produce identically shaped ES samples.
+	parsed, err := g.injector.demuxFMP4(data, variant)
+	if err != nil {
+		return nil, fmt.Errorf("demux slate: %w", err)
+	}
+
+	g.cache[key] = parsed
+
+	g.logger.Info("rendered error slate",
+		slog.String("variant", string(variant)),
+		slog.String("kind", string(se.Kind)),
+		slog.String("headline", se.Headline),
+		slog.Int("video_samples", len(parsed.VideoSamples)),
+		slog.Int("audio_samples", len(parsed.AudioSamples)),
+		slog.Duration("encode_time", time.Since(start)),
+	)
+
+	return parsed, nil
+}
+
+// slateUnsupportedVideoCodecs lists codecs we will not render a slate in even
+// when FFmpeg can encode them.
+//
+// AV1 is excluded because mediacommon's fMP4 parsing does not handle it -- the
+// same limitation buffer_injector.go documents for the embedded AV1 placeholder.
+// FFmpeg encodes it happily and the demux then fails with "not enough bits", so
+// the check has to be here rather than left to the encoder probe.
+var slateUnsupportedVideoCodecs = map[string]bool{
+	"av1": true,
+}
+
+// encoderProbe caches which encoders the FFmpeg binary actually provides.
+type encoderProbe struct {
+	once     sync.Once
+	encoders map[string]bool
+	err      error
+}
+
+var ffmpegEncoders sync.Map // ffmpeg path -> *encoderProbe
+
+// availableEncoders asks the FFmpeg binary what it can encode, once per binary.
+//
+// The codec registry knows libaom-av1 exists; it cannot know whether the build
+// in this image was compiled with it. The tvarr image ships a custom FFmpeg, so
+// capability has to be read from the binary rather than assumed.
+func availableEncoders(ffmpegPath string) (map[string]bool, error) {
+	v, _ := ffmpegEncoders.LoadOrStore(ffmpegPath, &encoderProbe{})
+	probe := v.(*encoderProbe)
+
+	probe.once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		out, err := exec.CommandContext(ctx, ffmpegPath, "-hide_banner", "-encoders").Output()
+		if err != nil {
+			probe.err = fmt.Errorf("probing ffmpeg encoders: %w", err)
+			return
+		}
+
+		found := make(map[string]bool)
+		for _, line := range strings.Split(string(out), "\n") {
+			// Lines look like " V....D libx264   libx264 H.264 / AVC ...".
+			fields := strings.Fields(line)
+			if len(fields) < 2 || !strings.HasPrefix(line, " ") {
+				continue
+			}
+			found[fields[1]] = true
+		}
+		probe.encoders = found
+	})
+
+	return probe.encoders, probe.err
+}
+
+// checkEncodable reports whether a slate can be produced for the variant.
+func (g *ErrorSlateGenerator) checkEncodable(variant CodecVariant, videoEncoder, audioEncoder string) error {
+	if slateUnsupportedVideoCodecs[variant.VideoCodec()] {
+		return fmt.Errorf("%w: %s cannot be demuxed back to ES samples", ErrGeneratorNoEncoder, variant.VideoCodec())
+	}
+	if videoEncoder == "" {
+		return fmt.Errorf("%w: no encoder for %s", ErrGeneratorNoEncoder, variant.VideoCodec())
+	}
+
+	encoders, err := availableEncoders(g.config.FFmpegPath)
+	if err != nil {
+		// If the probe itself failed, let the encode attempt produce the real
+		// error rather than blocking a slate we might have been able to render.
+		g.logger.Warn("could not probe ffmpeg encoders",
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	if !encoders[videoEncoder] {
+		return fmt.Errorf("%w: ffmpeg has no %s", ErrGeneratorNoEncoder, videoEncoder)
+	}
+	if audioEncoder != "" && !encoders[audioEncoder] {
+		return fmt.Errorf("%w: ffmpeg has no %s", ErrGeneratorNoEncoder, audioEncoder)
+	}
+	return nil
+}
+
+// encode rasterises the slate and encodes it to a fragmented MP4.
+func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, se *StreamError) ([]byte, error) {
+	videoEncoder := codec.GetVideoEncoder(codec.Video(variant.VideoCodec()), codec.HWAccelNone)
+	audioEncoder := codec.GetAudioEncoder(codec.Audio(variant.AudioCodec()))
+	if err := g.checkEncodable(variant, videoEncoder, audioEncoder); err != nil {
+		return nil, err
+	}
+
+	img := g.render(se)
+	frame := rgbaFrameBytes(img)
+	frameCount := max(int(g.config.Duration*float64(g.config.FrameRate)), 1)
+
+	ctx, cancel := context.WithTimeout(ctx, g.config.Timeout)
+	defer cancel()
+
+	args := []string{
+		"-hide_banner",
+		"-loglevel", "error",
+		// Raw RGBA frames on stdin. No demuxer probing, no font handling.
+		"-f", "rawvideo",
+		"-pixel_format", "rgba",
+		"-video_size", fmt.Sprintf("%dx%d", g.config.Width, g.config.Height),
+		"-framerate", fmt.Sprintf("%d", g.config.FrameRate),
+		"-i", "pipe:0",
+		// Silent audio so clients that expect an audio track keep their decoder
+		// alive across the switch into and back out of the slate.
+		"-f", "lavfi",
+		"-i", fmt.Sprintf("anullsrc=r=48000:cl=stereo:d=%.3f", g.config.Duration),
+		"-c:v", videoEncoder,
+		"-pix_fmt", "yuv420p",
+		"-b:v", fmt.Sprintf("%dk", g.config.VideoBitrate),
+		// Every frame a keyframe: the slate is looped by re-injecting its samples,
+		// and a consumer joining mid-loop must be able to decode immediately.
+		"-g", "1",
+		"-c:a", audioEncoder,
+		"-b:a", "96k",
+		"-shortest",
+		"-f", "mp4",
+		"-movflags", "+frag_keyframe+empty_moov+default_base_moof",
+		"pipe:1",
+	}
+
+	// x264/x265 need their still-image tunings passed before the output.
+	if videoEncoder == "libx264" || videoEncoder == "libx265" {
+		args = insertEncoderTuning(args, videoEncoder)
+	}
+
+	cmd := exec.CommandContext(ctx, g.config.FFmpegPath, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start ffmpeg: %w", err)
+	}
+
+	// Feed the identical frame frameCount times. The encoder collapses them to
+	// near-nothing, and this avoids relying on the loop filter being compiled in.
+	writeErr := func() error {
+		defer stdin.Close()
+		for range frameCount {
+			if _, err := stdin.Write(frame); err != nil {
+				return err
+			}
+		}
+		return nil
+	}()
+
+	waitErr := cmd.Wait()
+
+	if waitErr != nil {
+		return nil, fmt.Errorf("ffmpeg failed: %w (stderr: %s)", waitErr, strings.TrimSpace(stderr.String()))
+	}
+	// A broken pipe once ffmpeg has exited cleanly is benign: it means the encoder
+	// had all the frames it needed. Only surface a write error that lost frames.
+	if writeErr != nil && stdout.Len() == 0 {
+		return nil, fmt.Errorf("feeding frames to ffmpeg: %w", writeErr)
+	}
+	if stdout.Len() == 0 {
+		return nil, errors.New("ffmpeg produced no output")
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// insertEncoderTuning adds still-image tunings immediately after the encoder
+// selection so they bind to the video stream.
+func insertEncoderTuning(args []string, encoder string) []string {
+	out := make([]string, 0, len(args)+4)
+	for i, a := range args {
+		out = append(out, a)
+		if a == encoder && i > 0 && args[i-1] == "-c:v" {
+			out = append(out, "-preset", "ultrafast", "-tune", "stillimage")
+		}
+	}
+	return out
+}
+
+// Slate colours. Deliberately dark: these appear full-screen on a television,
+// often at night, and a bright slate after a failed channel change is hostile.
+var (
+	slateBackground = color.RGBA{R: 0x0d, G: 0x0f, B: 0x14, A: 0xff}
+	slateAccent     = color.RGBA{R: 0xe5, G: 0x48, B: 0x4b, A: 0xff}
+	slateHeadline   = color.RGBA{R: 0xf5, G: 0xf5, B: 0xf7, A: 0xff}
+	slateDetail     = color.RGBA{R: 0x9a, G: 0xa4, B: 0xb2, A: 0xff}
+)
+
+// render rasterises the slate for an error.
+func (g *ErrorSlateGenerator) render(se *StreamError) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, g.config.Width, g.config.Height))
+	draw.Draw(img, img.Bounds(), &image.Uniform{slateBackground}, image.Point{}, draw.Src)
+
+	headScale := g.config.Scale
+	detailScale := max(g.config.Scale-1, 1)
+
+	// A thin accent rule above the headline gives the slate an obvious top edge
+	// on displays that overscan.
+	ruleW := g.config.Width / 3
+	ruleH := max(g.config.Scale, 2)
+	ruleY := g.config.Height/2 - 12*headScale - 6*ruleH
+	drawRect(img, (g.config.Width-ruleW)/2, ruleY, ruleW, ruleH, slateAccent)
+
+	headFace := inconsolata.Bold8x16
+	headText := se.Headline
+	headW := textWidth(headFace, headText) * headScale
+	drawScaledText(img, headFace, headText,
+		(g.config.Width-headW)/2, g.config.Height/2, headScale, slateHeadline)
+
+	// Wrap the detail so a long provider message does not run off the raster.
+	detailFace := basicfont.Face7x13
+	maxChars := max((g.config.Width-80)/(detailFace.Advance*detailScale), 20)
+	lines := wrapText(se.Detail, maxChars)
+
+	y := g.config.Height/2 + 10*headScale
+	for _, line := range lines {
+		w := textWidth(detailFace, line) * detailScale
+		drawScaledText(img, detailFace, line, (g.config.Width-w)/2, y, detailScale, slateDetail)
+		y += 16 * detailScale
+	}
+
+	return img
+}
+
+// drawRect fills an axis-aligned rectangle.
+func drawRect(dst *image.RGBA, x, y, w, h int, c color.RGBA) {
+	r := image.Rect(x, y, x+w, y+h).Intersect(dst.Bounds())
+	if r.Empty() {
+		return
+	}
+	draw.Draw(dst, r, &image.Uniform{c}, image.Point{}, draw.Src)
+}
+
+// textWidth returns the unscaled pixel width of s in the given face.
+func textWidth(face font.Face, s string) int {
+	d := &font.Drawer{Face: face}
+	return d.MeasureString(s).Round()
+}
+
+// drawScaledText renders text with a bitmap face and nearest-neighbour upscales
+// it by scale. Bitmap fonts avoid shipping a TTF and, scaled by an integer
+// factor, stay crisp instead of the blur a resampled glyph would give.
+func drawScaledText(dst *image.RGBA, face font.Face, s string, x, y, scale int, c color.RGBA) {
+	if s == "" {
+		return
+	}
+
+	w := textWidth(face, s)
+	m := face.Metrics()
+	h := (m.Ascent + m.Descent).Round()
+	if w <= 0 || h <= 0 {
+		return
+	}
+
+	// Render once at 1x into a scratch mask.
+	scratch := image.NewRGBA(image.Rect(0, 0, w, h))
+	d := &font.Drawer{
+		Dst:  scratch,
+		Src:  &image.Uniform{c},
+		Face: face,
+		Dot:  fixed.P(0, m.Ascent.Round()),
+	}
+	d.DrawString(s)
+
+	// Blit each source pixel as a scale x scale block.
+	for sy := range h {
+		for sx := range w {
+			if scratch.RGBAAt(sx, sy).A == 0 {
+				continue
+			}
+			drawRect(dst, x+sx*scale, y+sy*scale, scale, scale, c)
+		}
+	}
+}
+
+// wrapText breaks s onto lines of at most width characters, splitting on spaces.
+func wrapText(s string, width int) []string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return nil
+	}
+
+	var (
+		lines []string
+		cur   strings.Builder
+	)
+	for _, f := range fields {
+		if cur.Len() > 0 && cur.Len()+1+len(f) > width {
+			lines = append(lines, cur.String())
+			cur.Reset()
+		}
+		if cur.Len() > 0 {
+			cur.WriteByte(' ')
+		}
+		cur.WriteString(f)
+	}
+	if cur.Len() > 0 {
+		lines = append(lines, cur.String())
+	}
+	return lines
+}
+
+// rgbaFrameBytes returns the tightly packed RGBA bytes for one frame. image.RGBA
+// may carry a stride wider than the row, which the rawvideo demuxer would read
+// as skewed pixels, so rows are copied out individually when that happens.
+func rgbaFrameBytes(img *image.RGBA) []byte {
+	b := img.Bounds()
+	rowLen := b.Dx() * 4
+	if img.Stride == rowLen {
+		return img.Pix
+	}
+
+	out := make([]byte, 0, rowLen*b.Dy())
+	for y := range b.Dy() {
+		start := y * img.Stride
+		out = append(out, img.Pix[start:start+rowLen]...)
+	}
+	return out
+}
+
+// InjectErrorSlate loops slate samples into the variant starting at startPTS and
+// returns the PTS immediately after the last sample written.
+//
+// Timestamps continue from the caller's startPTS rather than restarting at zero.
+// A decoder that sees PTS jump backwards when the stream switches to the slate
+// treats it as a discontinuity and, on most clients, drops the stream -- which
+// is the dead stream this whole path exists to avoid.
+func InjectErrorSlate(variant *ESVariant, slate *CachedPlaceholder, startPTS int64, target time.Duration) int64 {
+	if variant == nil || slate == nil || len(slate.VideoSamples) == 0 {
+		return startPTS
+	}
+
+	// Only adopt the slate's init data when the variant has none. Overwriting
+	// live SPS/PPS mid-stream would change the decoder configuration underneath
+	// a client that has already started decoding.
+	if variant.VideoTrack().GetInitData() == nil && len(slate.VideoInitData) > 0 {
+		variant.VideoTrack().SetInitData(slate.VideoInitData)
+	}
+	if variant.AudioTrack().GetInitData() == nil && len(slate.AudioInitData) > 0 {
+		variant.AudioTrack().SetInitData(slate.AudioInitData)
+	}
+
+	loopPTS := int64(slate.Duration.Seconds() * 90000)
+	if loopPTS <= 0 {
+		loopPTS = int64(90000)
+	}
+	loops := max(int(target/slate.Duration), 1)
+
+	videoTrack := variant.VideoTrack()
+	audioTrack := variant.AudioTrack()
+
+	for loop := range loops {
+		offset := startPTS + int64(loop)*loopPTS
+		for _, s := range slate.VideoSamples {
+			videoTrack.Write(s.PTS+offset, s.DTS+offset, s.Data, s.IsKeyframe)
+		}
+		for _, s := range slate.AudioSamples {
+			audioTrack.Write(s.PTS+offset, s.DTS+offset, s.Data, s.IsKeyframe)
+		}
+	}
+
+	return startPTS + int64(loops)*loopPTS
+}

--- a/internal/relay/error_slate.go
+++ b/internal/relay/error_slate.go
@@ -501,6 +501,14 @@ func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, 
 		"-f", "lavfi",
 		"-i", fmt.Sprintf("anullsrc=r=48000:cl=stereo:d=%.3f", g.config.Duration),
 		"-c:v", videoEncoder,
+	}
+
+	// x264/x265 still-image tunings, bound to the video stream.
+	if videoEncoder == "libx264" || videoEncoder == "libx265" {
+		args = append(args, "-preset", "ultrafast", "-tune", "stillimage")
+	}
+
+	args = append(args,
 		"-pix_fmt", "yuv420p",
 		"-b:v", fmt.Sprintf("%dk", g.config.VideoBitrate),
 		// Every frame a keyframe: the slate is looped by re-injecting its samples,
@@ -512,12 +520,7 @@ func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, 
 		"-f", "mp4",
 		"-movflags", "+frag_keyframe+empty_moov+default_base_moof",
 		"pipe:1",
-	}
-
-	// x264/x265 need their still-image tunings passed before the output.
-	if videoEncoder == "libx264" || videoEncoder == "libx265" {
-		args = insertEncoderTuning(args, videoEncoder)
-	}
+	)
 
 	cmd := exec.CommandContext(ctx, g.config.FFmpegPath, args...)
 
@@ -561,19 +564,6 @@ func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, 
 	}
 
 	return stdout.Bytes(), nil
-}
-
-// insertEncoderTuning adds still-image tunings immediately after the encoder
-// selection so they bind to the video stream.
-func insertEncoderTuning(args []string, encoder string) []string {
-	out := make([]string, 0, len(args)+4)
-	for i, a := range args {
-		out = append(out, a)
-		if a == encoder && i > 0 && args[i-1] == "-c:v" {
-			out = append(out, "-preset", "ultrafast", "-tune", "stillimage")
-		}
-	}
-	return out
 }
 
 // Slate colours. Deliberately dark: these appear full-screen on a television,

--- a/internal/relay/error_slate.go
+++ b/internal/relay/error_slate.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/basicfont"
 	"golang.org/x/image/font/inconsolata"
@@ -302,20 +304,44 @@ func NewErrorSlateGenerator(config ErrorSlateConfig, logger *slog.Logger) *Error
 	}
 }
 
-// cacheKey combines the variant and the error, since the same message must be
-// encoded once per codec variant.
-func (g *ErrorSlateGenerator) cacheKey(variant CodecVariant, se *StreamError) string {
-	return string(variant) + "\x00" + se.CacheKey()
+// cacheKey combines variant, size and message: the same text must be encoded
+// once per codec variant AND per resolution, because a slate spliced onto a live
+// track has to match the parameter sets that track already advertises.
+func (g *ErrorSlateGenerator) cacheKey(variant CodecVariant, size SlateSize, se *StreamError) string {
+	return fmt.Sprintf("%s\x00%dx%d\x00%s", variant, size.Width, size.Height, se.CacheKey())
 }
 
-// Slate returns ES samples rendering the error for the variant, encoding on
-// first use and serving from cache afterwards.
-func (g *ErrorSlateGenerator) Slate(ctx context.Context, variant CodecVariant, se *StreamError) (*CachedPlaceholder, error) {
+// SlateSize is the raster size of a slate. Zero values mean "use the
+// generator's configured default".
+type SlateSize struct {
+	Width  int
+	Height int
+}
+
+// normalise fills in generator defaults for any zero dimension and forces even
+// dimensions, which yuv420p requires.
+func (s SlateSize) normalise(cfg ErrorSlateConfig) SlateSize {
+	if s.Width <= 0 || s.Height <= 0 {
+		s = SlateSize{Width: cfg.Width, Height: cfg.Height}
+	}
+	s.Width &^= 1
+	s.Height &^= 1
+	return s
+}
+
+// Slate returns ES samples rendering the error for the variant at the requested
+// size, encoding on first use and serving from cache afterwards.
+//
+// Size matters as much as codec. Splicing a 720p slate onto a track that has
+// already published 1080p SPS/PPS gives the decoder slices its parameter sets do
+// not describe, so callers pass the live stream's resolution when there is one.
+func (g *ErrorSlateGenerator) Slate(ctx context.Context, variant CodecVariant, se *StreamError, size SlateSize) (*CachedPlaceholder, error) {
 	if se == nil {
 		return nil, errors.New("nil stream error")
 	}
 
-	key := g.cacheKey(variant, se)
+	size = size.normalise(g.config)
+	key := g.cacheKey(variant, size, se)
 
 	g.mu.RLock()
 	cached, ok := g.cache[key]
@@ -334,7 +360,7 @@ func (g *ErrorSlateGenerator) Slate(ctx context.Context, variant CodecVariant, s
 
 	start := time.Now()
 
-	data, err := g.encode(ctx, variant, se)
+	data, err := g.encode(ctx, variant, se, size)
 	if err != nil {
 		return nil, err
 	}
@@ -346,10 +372,15 @@ func (g *ErrorSlateGenerator) Slate(ctx context.Context, variant CodecVariant, s
 		return nil, fmt.Errorf("demux slate: %w", err)
 	}
 
+	if err := toAnnexBInPlace(parsed, variant); err != nil {
+		return nil, fmt.Errorf("converting slate to the live sample format: %w", err)
+	}
+
 	g.cache[key] = parsed
 
 	g.logger.Info("rendered error slate",
 		slog.String("variant", string(variant)),
+		slog.String("size", fmt.Sprintf("%dx%d", size.Width, size.Height)),
 		slog.String("kind", string(se.Kind)),
 		slog.String("headline", se.Headline),
 		slog.Int("video_samples", len(parsed.VideoSamples)),
@@ -442,14 +473,14 @@ func (g *ErrorSlateGenerator) checkEncodable(variant CodecVariant, videoEncoder,
 }
 
 // encode rasterises the slate and encodes it to a fragmented MP4.
-func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, se *StreamError) ([]byte, error) {
+func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, se *StreamError, size SlateSize) ([]byte, error) {
 	videoEncoder := codec.GetVideoEncoder(codec.Video(variant.VideoCodec()), codec.HWAccelNone)
 	audioEncoder := codec.GetAudioEncoder(codec.Audio(variant.AudioCodec()))
 	if err := g.checkEncodable(variant, videoEncoder, audioEncoder); err != nil {
 		return nil, err
 	}
 
-	img := g.render(se)
+	img := g.render(se, size)
 	frame := rgbaFrameBytes(img)
 	frameCount := max(int(g.config.Duration*float64(g.config.FrameRate)), 1)
 
@@ -462,7 +493,7 @@ func (g *ErrorSlateGenerator) encode(ctx context.Context, variant CodecVariant, 
 		// Raw RGBA frames on stdin. No demuxer probing, no font handling.
 		"-f", "rawvideo",
 		"-pixel_format", "rgba",
-		"-video_size", fmt.Sprintf("%dx%d", g.config.Width, g.config.Height),
+		"-video_size", fmt.Sprintf("%dx%d", size.Width, size.Height),
 		"-framerate", fmt.Sprintf("%d", g.config.FrameRate),
 		"-i", "pipe:0",
 		// Silent audio so clients that expect an audio track keep their decoder
@@ -554,36 +585,40 @@ var (
 	slateDetail     = color.RGBA{R: 0x9a, G: 0xa4, B: 0xb2, A: 0xff}
 )
 
-// render rasterises the slate for an error.
-func (g *ErrorSlateGenerator) render(se *StreamError) *image.RGBA {
-	img := image.NewRGBA(image.Rect(0, 0, g.config.Width, g.config.Height))
+// render rasterises the slate for an error at the given size.
+func (g *ErrorSlateGenerator) render(se *StreamError, size SlateSize) *image.RGBA {
+	size = size.normalise(g.config)
+
+	img := image.NewRGBA(image.Rect(0, 0, size.Width, size.Height))
 	draw.Draw(img, img.Bounds(), &image.Uniform{slateBackground}, image.Point{}, draw.Src)
 
-	headScale := g.config.Scale
-	detailScale := max(g.config.Scale-1, 1)
+	// Scale typography with the raster so a 4K slate is not captioned in text
+	// sized for 720p, and an SD one does not overflow.
+	headScale := max(g.config.Scale*size.Height/720, 1)
+	detailScale := max(headScale-1, 1)
 
 	// A thin accent rule above the headline gives the slate an obvious top edge
 	// on displays that overscan.
-	ruleW := g.config.Width / 3
-	ruleH := max(g.config.Scale, 2)
-	ruleY := g.config.Height/2 - 12*headScale - 6*ruleH
-	drawRect(img, (g.config.Width-ruleW)/2, ruleY, ruleW, ruleH, slateAccent)
+	ruleW := size.Width / 3
+	ruleH := max(headScale, 2)
+	ruleY := size.Height/2 - 12*headScale - 6*ruleH
+	drawRect(img, (size.Width-ruleW)/2, ruleY, ruleW, ruleH, slateAccent)
 
 	headFace := inconsolata.Bold8x16
 	headText := se.Headline
 	headW := textWidth(headFace, headText) * headScale
 	drawScaledText(img, headFace, headText,
-		(g.config.Width-headW)/2, g.config.Height/2, headScale, slateHeadline)
+		(size.Width-headW)/2, size.Height/2, headScale, slateHeadline)
 
 	// Wrap the detail so a long provider message does not run off the raster.
 	detailFace := basicfont.Face7x13
-	maxChars := max((g.config.Width-80)/(detailFace.Advance*detailScale), 20)
+	maxChars := max((size.Width-80)/(detailFace.Advance*detailScale), 20)
 	lines := wrapText(se.Detail, maxChars)
 
-	y := g.config.Height/2 + 10*headScale
+	y := size.Height/2 + 10*headScale
 	for _, line := range lines {
 		w := textWidth(detailFace, line) * detailScale
-		drawScaledText(img, detailFace, line, (g.config.Width-w)/2, y, detailScale, slateDetail)
+		drawScaledText(img, detailFace, line, (size.Width-w)/2, y, detailScale, slateDetail)
 		y += 16 * detailScale
 	}
 
@@ -686,6 +721,122 @@ func rgbaFrameBytes(img *image.RGBA) []byte {
 	return out
 }
 
+// toAnnexBInPlace rewrites slate samples into the format the live pipeline uses.
+//
+// The two sources disagree, and splicing them onto one track without this is
+// undecodable no matter how well the timestamps line up:
+//
+//   - The TS demuxer emits Annex-B (h264.AnnexB(au).Marshal()) with SPS/PPS
+//     carried inline in each keyframe access unit, and sets the track's init data
+//     to nil, because that is how MPEG-TS delivers parameter sets.
+//   - fMP4 samples are AVCC -- length-prefixed NAL units -- with the parameter
+//     sets held once in the init segment and never in the samples.
+//
+// So each slate sample is converted to Annex-B, and the parameter sets recovered
+// from the fMP4 init data are prepended to every keyframe. A decoder joining on a
+// slate keyframe then has everything it needs from the sample alone, exactly as
+// it would from the live stream.
+func toAnnexBInPlace(p *CachedPlaceholder, variant CodecVariant) error {
+	var params [][]byte
+
+	switch variant.VideoCodec() {
+	case "h264", "avc":
+		sps, pps := parseH264InitData(p.VideoInitData)
+		if len(sps) > 0 {
+			params = append(params, sps)
+		}
+		if len(pps) > 0 {
+			params = append(params, pps)
+		}
+	case "h265", "hevc":
+		vps, sps, pps := parseH265InitData(p.VideoInitData)
+		for _, nal := range [][]byte{vps, sps, pps} {
+			if len(nal) > 0 {
+				params = append(params, nal)
+			}
+		}
+	default:
+		// Other codecs are not spliced onto an Annex-B track.
+		return nil
+	}
+
+	for i, sample := range p.VideoSamples {
+		var avcc h264.AVCC
+		if err := avcc.Unmarshal(sample.Data); err != nil {
+			return fmt.Errorf("sample %d: %w", i, err)
+		}
+
+		au := [][]byte(avcc)
+		if len(params) > 0 {
+			au = append(append([][]byte{}, params...), au...)
+		}
+
+		annexB, err := h264.AnnexB(au).Marshal()
+		if err != nil {
+			return fmt.Errorf("sample %d: %w", i, err)
+		}
+		p.VideoSamples[i].Data = annexB
+
+		// Every slate frame is encoded with -g 1, so every one is an IDR and
+		// now carries its own parameter sets. Marking them says so.
+		//
+		// This is not cosmetic: the fMP4 sample flags come back with no keyframe
+		// set at all, and the output processors pull via ReadFromKeyframe. Left
+		// unmarked, consumers find no keyframe to start from and the slate never
+		// reaches the viewer -- the dead stream, one layer further down.
+		p.VideoSamples[i].IsKeyframe = true
+	}
+
+	// The parameter sets now travel in the samples, so the init data must not be
+	// published as well: a live track never has any, and adopting it here would
+	// make the slate's track shape differ from the stream it replaces.
+	p.VideoInitData = nil
+
+	return nil
+}
+
+// spsSizeFromAnnexB scans an Annex-B access unit for a parameter set and returns
+// the coded resolution it describes.
+//
+// Live MPEG-TS keeps SPS inline in keyframes rather than in track init data, so
+// this is the only place the live resolution can actually be read from.
+func spsSizeFromAnnexB(data []byte, videoCodec string) (SlateSize, bool) {
+	var au h264.AnnexB
+	if err := au.Unmarshal(data); err != nil {
+		return SlateSize{}, false
+	}
+
+	for _, nal := range au {
+		if len(nal) == 0 {
+			continue
+		}
+
+		switch videoCodec {
+		case "h264", "avc":
+			if nal[0]&0x1f != 7 { // SPS
+				continue
+			}
+			var sps h264.SPS
+			if err := sps.Unmarshal(nal); err != nil {
+				continue
+			}
+			return SlateSize{Width: sps.Width(), Height: sps.Height()}, true
+
+		case "h265", "hevc":
+			if len(nal) < 2 || (nal[0]>>1)&0x3f != 33 { // SPS
+				continue
+			}
+			var sps h265.SPS
+			if err := sps.Unmarshal(nal); err != nil {
+				continue
+			}
+			return SlateSize{Width: sps.Width(), Height: sps.Height()}, true
+		}
+	}
+
+	return SlateSize{}, false
+}
+
 // InjectErrorSlate loops slate samples into the variant starting at startPTS and
 // returns the PTS immediately after the last sample written.
 //
@@ -698,12 +849,12 @@ func InjectErrorSlate(variant *ESVariant, slate *CachedPlaceholder, startPTS int
 		return startPTS
 	}
 
-	// Only adopt the slate's init data when the variant has none. Overwriting
-	// live SPS/PPS mid-stream would change the decoder configuration underneath
-	// a client that has already started decoding.
-	if variant.VideoTrack().GetInitData() == nil && len(slate.VideoInitData) > 0 {
-		variant.VideoTrack().SetInitData(slate.VideoInitData)
-	}
+	// Video parameter sets travel inline in the samples (see toAnnexBInPlace), so
+	// nothing is published to the video track here: a live track carries no video
+	// init data either, and the slate must not make the track look different.
+	//
+	// Audio is the opposite: AAC config lives in the track's init data in both
+	// paths, so adopt it only when the track has none of its own.
 	if variant.AudioTrack().GetInitData() == nil && len(slate.AudioInitData) > 0 {
 		variant.AudioTrack().SetInitData(slate.AudioInitData)
 	}

--- a/internal/relay/error_slate_stream_test.go
+++ b/internal/relay/error_slate_stream_test.go
@@ -1,0 +1,318 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// These tests exercise the slate splice against real encoded media rather than
+// hand-built samples. There is no live provider to test against -- and one would
+// be useless for this anyway, since reproducing a mid-stream failure on demand is
+// exactly what a real origin will not do -- so a synthetic MPEG-TS stream stands
+// in for the origin. It carries genuine H.264 SPS/PPS and a real PTS timeline,
+// which is what the PTS-continuity and resolution-matching logic actually depends
+// on.
+
+// syntheticTS renders a short MPEG-TS test stream at the given size and returns
+// its bytes. It skips the test when ffmpeg is unavailable.
+func syntheticTS(t *testing.T, width, height int, seconds float64) []byte {
+	t.Helper()
+
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not available")
+	}
+
+	out := filepath.Join(t.TempDir(), "synthetic.ts")
+
+	cmd := exec.Command(ffmpegPath,
+		"-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", fmt.Sprintf("testsrc=size=%dx%d:rate=25:duration=%.2f", width, height, seconds),
+		"-f", "lavfi", "-i", fmt.Sprintf("sine=frequency=440:duration=%.2f", seconds),
+		"-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", "-g", "25",
+		"-c:a", "aac", "-b:a", "96k",
+		"-f", "mpegts", "-y", out,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not build synthetic stream: %v (%s)", err, output)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading synthetic stream: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("synthetic stream is empty")
+	}
+	return data
+}
+
+// ingestSynthetic feeds a TS stream through a demuxer into a fresh buffer and
+// waits for samples to land. rebaseTarget of 0 means no rebasing.
+func ingestSynthetic(t *testing.T, data []byte, rebaseTarget int64) *SharedESBuffer {
+	t.Helper()
+
+	buffer := NewSharedESBuffer("test-channel", "test-proxy", SharedESBufferConfig{})
+
+	demuxer := NewTSDemuxer(buffer, TSDemuxerConfig{
+		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		PTSRebaseTarget: rebaseTarget,
+	})
+
+	var once sync.Once
+	defer once.Do(func() { demuxer.Close() })
+
+	if err := demuxer.Write(data); err != nil {
+		t.Fatalf("writing to demuxer: %v", err)
+	}
+
+	// The demuxer parses on its own goroutine; wait for the source variant to
+	// appear rather than sleeping a fixed amount.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := buffer.WaitSourceVariant(ctx); err != nil {
+		t.Skipf("demuxer produced no source variant: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := buffer.GetSourceVariant(); v != nil && v.VideoTrack().LatestPTS() > 0 {
+			return buffer
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Skip("synthetic stream produced no video samples in time")
+	return nil
+}
+
+// TestSlateSplicesOntoLiveTimeline is the regression test for the defect this
+// work fixed: the slate used to splice in at PTS 0 regardless of how far the live
+// stream had already run, which decoders read as a backwards jump.
+func TestSlateSplicesOntoLiveTimeline(t *testing.T) {
+	data := syntheticTS(t, 640, 360, 2)
+	buffer := ingestSynthetic(t, data, 0)
+
+	live := buffer.GetSourceVariant()
+	livePTS := live.VideoTrack().LatestPTS()
+	if livePTS <= 0 {
+		t.Fatalf("synthetic stream produced no usable PTS (got %d)", livePTS)
+	}
+	t.Logf("live stream ended at PTS %d", livePTS)
+
+	ffmpegPath, _ := exec.LookPath("ffmpeg")
+	cfg := DefaultErrorSlateConfig()
+	cfg.FFmpegPath = ffmpegPath
+	cfg.Duration = 0.5
+	cfg.FrameRate = 5
+	g := NewErrorSlateGenerator(cfg, nil)
+
+	// Mirror what serveErrorSlate does: match the live raster, continue the
+	// live timeline.
+	session := &RelaySession{}
+	size, matched := session.liveVideoSize(live)
+	if !matched {
+		t.Fatal("could not read the live resolution from the stream's own SPS")
+	}
+	if size.Width != 640 || size.Height != 360 {
+		t.Errorf("live size = %dx%d, want 640x360", size.Width, size.Height)
+	}
+
+	slate, err := g.Slate(context.Background(), live.Variant(), NewUpstreamStatusError(555), size)
+	if err != nil {
+		t.Fatalf("rendering slate at the live size: %v", err)
+	}
+
+	InjectErrorSlate(live, slate, livePTS+slatePTSGap, 2*time.Second)
+
+	// Every sample on the track, live and slate, must move forward in time.
+	samples := live.VideoTrack().ReadFrom(0, 100000)
+	if len(samples) < 2 {
+		t.Fatalf("expected live and slate samples, got %d", len(samples))
+	}
+
+	var (
+		prev       int64 = -1
+		regression int
+	)
+	for _, s := range samples {
+		if s.PTS < prev {
+			regression++
+			t.Errorf("PTS went backwards: %d after %d", s.PTS, prev)
+		}
+		prev = s.PTS
+	}
+	if regression == 0 {
+		t.Logf("timeline intact across %d samples, ending at PTS %d", len(samples), prev)
+	}
+	if prev <= livePTS {
+		t.Errorf("slate did not extend the timeline: ends at %d, live ended at %d", prev, livePTS)
+	}
+}
+
+// TestSlateMatchesLiveResolution guards the parameter-set half of the splice: the
+// track keeps its live SPS/PPS, so slate slices of a different size would not be
+// described by them.
+func TestSlateMatchesLiveResolution(t *testing.T) {
+	for _, size := range []struct{ w, h int }{{640, 360}, {1280, 720}} {
+		t.Run(fmt.Sprintf("%dx%d", size.w, size.h), func(t *testing.T) {
+			data := syntheticTS(t, size.w, size.h, 1)
+			buffer := ingestSynthetic(t, data, 0)
+
+			live := buffer.GetSourceVariant()
+			session := &RelaySession{}
+
+			got, ok := session.liveVideoSize(live)
+			if !ok {
+				t.Fatal("could not read resolution from the live SPS")
+			}
+			if got.Width != size.w || got.Height != size.h {
+				t.Errorf("liveVideoSize = %dx%d, want %dx%d", got.Width, got.Height, size.w, size.h)
+			}
+		})
+	}
+}
+
+// TestResumedStreamIsRebasedOntoSlate covers the return leg: a recovered origin
+// restarts on its own timeline, and without a shift that is a backwards jump just
+// as bad as the one going in.
+func TestResumedStreamIsRebasedOntoSlate(t *testing.T) {
+	data := syntheticTS(t, 640, 360, 1)
+
+	// Where the slate is deemed to have ended -- far beyond anything the
+	// synthetic stream's own timeline would reach on its own.
+	const slateEndPTS = int64(50_000_000)
+
+	buffer := ingestSynthetic(t, data, slateEndPTS+slatePTSGap)
+
+	resumed := buffer.GetSourceVariant()
+	samples := resumed.VideoTrack().ReadFrom(0, 100000)
+	if len(samples) == 0 {
+		t.Fatal("resumed stream produced no samples")
+	}
+
+	if first := samples[0].PTS; first < slateEndPTS {
+		t.Errorf("resumed stream starts at PTS %d, before the slate ended at %d - the viewer's decoder sees time run backwards",
+			first, slateEndPTS)
+	}
+
+	var prev int64 = -1
+	for _, s := range samples {
+		if s.PTS < prev {
+			t.Errorf("resumed stream PTS went backwards: %d after %d", s.PTS, prev)
+		}
+		prev = s.PTS
+	}
+
+	// The shift must be a constant offset, not a rewrite: internal spacing has to
+	// survive or playback speed changes.
+	unshifted := ingestSynthetic(t, data, 0)
+	origSamples := unshifted.GetSourceVariant().VideoTrack().ReadFrom(0, 100000)
+	if len(origSamples) == len(samples) && len(samples) > 1 {
+		origSpan := origSamples[len(origSamples)-1].PTS - origSamples[0].PTS
+		newSpan := samples[len(samples)-1].PTS - samples[0].PTS
+		if origSpan != newSpan {
+			t.Errorf("rebasing changed the stream's duration: %d -> %d", origSpan, newSpan)
+		}
+	}
+}
+
+// TestLatestPTS covers the accessor the splice depends on.
+func TestLatestPTS(t *testing.T) {
+	variant := newTestESVariant(t)
+	track := variant.VideoTrack()
+
+	if got := track.LatestPTS(); got != 0 {
+		t.Errorf("empty track LatestPTS = %d, want 0", got)
+	}
+
+	track.Write(1000, 1000, []byte{0x01}, true)
+	track.Write(4600, 4600, []byte{0x02}, false)
+
+	if got := track.LatestPTS(); got != 4600 {
+		t.Errorf("LatestPTS = %d, want 4600", got)
+	}
+}
+
+func TestSlateSizeNormalise(t *testing.T) {
+	cfg := DefaultErrorSlateConfig()
+
+	if got := (SlateSize{}).normalise(cfg); got.Width != cfg.Width || got.Height != cfg.Height {
+		t.Errorf("zero size = %+v, want the config default", got)
+	}
+	// yuv420p cannot represent odd dimensions, so they must be rounded down.
+	if got := (SlateSize{Width: 641, Height: 361}).normalise(cfg); got.Width%2 != 0 || got.Height%2 != 0 {
+		t.Errorf("odd size not made even: %+v", got)
+	}
+}
+
+// TestSlateSamplesMatchLiveSampleFormat is the guard for the subtlest of the
+// splice bugs: correct timestamps on samples the decoder cannot parse still give
+// the viewer a dead stream.
+//
+// The live TS path emits Annex-B with parameter sets inline in keyframes; fMP4
+// samples are AVCC with the parameter sets held only in the init segment. Slate
+// samples must be converted to match, or they are undecodable on a live track.
+func TestSlateSamplesMatchLiveSampleFormat(t *testing.T) {
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not available")
+	}
+
+	cfg := DefaultErrorSlateConfig()
+	cfg.FFmpegPath = ffmpegPath
+	cfg.Width, cfg.Height = 640, 360
+	cfg.Duration = 0.5
+	cfg.FrameRate = 5
+
+	g := NewErrorSlateGenerator(cfg, nil)
+	slate, err := g.Slate(context.Background(), NewCodecVariant("h264", "aac"),
+		NewUpstreamStatusError(555), SlateSize{})
+	if err != nil {
+		t.Fatalf("rendering slate: %v", err)
+	}
+	if len(slate.VideoSamples) == 0 {
+		t.Fatal("slate produced no video samples")
+	}
+
+	// Parameter sets must not be published as track init data: a live track has
+	// none, and the slate must not make the track look different.
+	if slate.VideoInitData != nil {
+		t.Errorf("slate still publishes video init data (%d bytes); live tracks carry none",
+			len(slate.VideoInitData))
+	}
+
+	startCode := []byte{0, 0, 0, 1}
+	var keyframesWithSPS int
+
+	for i, sample := range slate.VideoSamples {
+		if !bytes.HasPrefix(sample.Data, startCode) && !bytes.HasPrefix(sample.Data, []byte{0, 0, 1}) {
+			t.Fatalf("sample %d is not Annex-B (starts %x) - it is still AVCC and will not decode on a live track",
+				i, sample.Data[:min(4, len(sample.Data))])
+		}
+
+		if !sample.IsKeyframe {
+			continue
+		}
+		if size, ok := spsSizeFromAnnexB(sample.Data, "h264"); ok {
+			keyframesWithSPS++
+			if size.Width != 640 || size.Height != 360 {
+				t.Errorf("keyframe %d SPS says %dx%d, want 640x360", i, size.Width, size.Height)
+			}
+		}
+	}
+
+	if keyframesWithSPS == 0 {
+		t.Error("no keyframe carries an inline SPS - a client joining on the slate has no parameter sets")
+	}
+	t.Logf("%d/%d slate samples are keyframes carrying inline SPS",
+		keyframesWithSPS, len(slate.VideoSamples))
+}

--- a/internal/relay/error_slate_test.go
+++ b/internal/relay/error_slate_test.go
@@ -1,0 +1,370 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestESVariant builds a standalone h264/aac variant for injection tests.
+func newTestESVariant(t *testing.T) *ESVariant {
+	t.Helper()
+	return NewESVariantWithMaxBytes(NewCodecVariant("h264", "aac"), 8<<20, true)
+}
+
+func TestNewUpstreamStatusError(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		wantKind StreamErrorKind
+		wantWord string
+	}{
+		// The two codes seen in production from the Xtream panel. Neither is a
+		// real HTTP status, and both mean the panel refused the stream while the
+		// same account still authenticates against player_api.php.
+		{"xtream 555", 555, StreamErrorLimitReached, "Too Many Connections"},
+		{"xtream 999", 999, StreamErrorLimitReached, "Too Many Connections"},
+		{"too many requests", 429, StreamErrorLimitReached, "Too Many Connections"},
+		{"bandwidth limit", 509, StreamErrorLimitReached, "Too Many Connections"},
+		{"unauthorized", 401, StreamErrorUnavailable, "Not Authorised"},
+		{"forbidden", 403, StreamErrorUnavailable, "Not Authorised"},
+		{"not found", 404, StreamErrorEnded, "Channel Not Found"},
+		{"gone", 410, StreamErrorEnded, "Channel Not Found"},
+		{"server error", 500, StreamErrorUnavailable, "Provider Error"},
+		{"bad gateway", 502, StreamErrorUnavailable, "Provider Error"},
+		{"teapot", 418, StreamErrorUnavailable, "Channel Unavailable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewUpstreamStatusError(tt.status)
+			if got.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", got.Kind, tt.wantKind)
+			}
+			if got.Headline != tt.wantWord {
+				t.Errorf("Headline = %q, want %q", got.Headline, tt.wantWord)
+			}
+			if got.HTTPStatus != tt.status {
+				t.Errorf("HTTPStatus = %d, want %d", got.HTTPStatus, tt.status)
+			}
+			// The status must reach the viewer: it is the one piece of detail that
+			// tells them (or us, from a photo of the TV) what the provider said.
+			if !strings.Contains(got.Detail, fmt.Sprintf("%d", tt.status)) {
+				t.Errorf("Detail %q does not mention status %d", got.Detail, tt.status)
+			}
+		})
+	}
+}
+
+func TestClassifyStreamError(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		if got := ClassifyStreamError(nil); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("existing StreamError passes through unchanged", func(t *testing.T) {
+		orig := NewUpstreamStatusError(555)
+		got := ClassifyStreamError(fmt.Errorf("wrapped: %w", orig))
+		if got != orig {
+			t.Fatalf("classification replaced the precise error: got %+v", got)
+		}
+		if got.Kind != StreamErrorLimitReached {
+			t.Errorf("Kind = %q, want %q", got.Kind, StreamErrorLimitReached)
+		}
+	})
+
+	t.Run("DNS failure names the host", func(t *testing.T) {
+		err := &net.DNSError{Err: "no such host", Name: "cf.bek252.xyz", IsNotFound: true}
+		got := ClassifyStreamError(err)
+		if got.Kind != StreamErrorUnavailable {
+			t.Errorf("Kind = %q, want %q", got.Kind, StreamErrorUnavailable)
+		}
+		if got.Headline != "Provider Not Found" {
+			t.Errorf("Headline = %q", got.Headline)
+		}
+		if !strings.Contains(got.Detail, "cf.bek252.xyz") {
+			t.Errorf("Detail %q does not name the host", got.Detail)
+		}
+	})
+
+	t.Run("context cancellation is not a failure", func(t *testing.T) {
+		got := ClassifyStreamError(context.Canceled)
+		if got.Kind != StreamErrorEnded {
+			t.Errorf("Kind = %q, want %q", got.Kind, StreamErrorEnded)
+		}
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		got := ClassifyStreamError(errors.New("dial tcp 1.2.3.4:80: connect: connection refused"))
+		if got.Headline != "Connection Refused" {
+			t.Errorf("Headline = %q", got.Headline)
+		}
+	})
+
+	t.Run("unknown error still yields a showable slate", func(t *testing.T) {
+		got := ClassifyStreamError(errors.New("something bizarre"))
+		if got.Headline == "" || got.Detail == "" {
+			t.Errorf("unknown error produced an unrenderable slate: %+v", got)
+		}
+	})
+
+	t.Run("unwrap exposes the cause", func(t *testing.T) {
+		cause := errors.New("root cause")
+		got := ClassifyStreamError(fmt.Errorf("outer: %w", cause))
+		if !errors.Is(got, cause) {
+			t.Errorf("errors.Is could not reach the cause")
+		}
+	})
+}
+
+func TestStreamErrorKindPlaceholderType(t *testing.T) {
+	tests := map[StreamErrorKind]PlaceholderType{
+		StreamErrorLimitReached: PlaceholderLimitReached,
+		StreamErrorEnded:        PlaceholderEnded,
+		StreamErrorStarting:     PlaceholderStarting,
+		StreamErrorUnavailable:  PlaceholderUnavailable,
+		StreamErrorKind("nope"): PlaceholderUnavailable,
+	}
+	for kind, want := range tests {
+		if got := kind.PlaceholderType(); got != want {
+			t.Errorf("%q.PlaceholderType() = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestStreamErrorCacheKeyDistinguishesMessages(t *testing.T) {
+	a := NewUpstreamStatusError(555)
+	b := NewUpstreamStatusError(999)
+	if a.CacheKey() == b.CacheKey() {
+		t.Error("555 and 999 share a cache key, so one would render the other's text")
+	}
+	if a.CacheKey() != NewUpstreamStatusError(555).CacheKey() {
+		t.Error("identical errors produced different cache keys, defeating the cache")
+	}
+}
+
+func TestWrapText(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		width int
+		want  int // expected line count
+	}{
+		{"empty", "", 20, 0},
+		{"short stays on one line", "hello world", 20, 1},
+		{"long wraps", "the quick brown fox jumps over the lazy dog", 15, 3},
+		{"word longer than width is not lost", "supercalifragilistic", 5, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapText(tt.in, tt.width)
+			if len(got) != tt.want {
+				t.Errorf("wrapText(%q, %d) = %d lines %q, want %d", tt.in, tt.width, len(got), got, tt.want)
+			}
+			// No content may be dropped by wrapping.
+			if strings.Join(strings.Fields(strings.Join(got, " ")), " ") !=
+				strings.Join(strings.Fields(tt.in), " ") {
+				t.Errorf("wrapText lost or reordered content: %q -> %q", tt.in, got)
+			}
+		})
+	}
+}
+
+func TestRGBAFrameBytesHandlesStridePadding(t *testing.T) {
+	// A sub-image has a stride wider than its row. Feeding img.Pix directly to
+	// the rawvideo demuxer would skew every row of the slate.
+	base := image.NewRGBA(image.Rect(0, 0, 16, 4))
+	sub := base.SubImage(image.Rect(0, 0, 8, 4)).(*image.RGBA)
+
+	got := rgbaFrameBytes(sub)
+	want := 8 * 4 * 4
+	if len(got) != want {
+		t.Errorf("len = %d, want %d (stride padding not stripped)", len(got), want)
+	}
+}
+
+func TestRenderProducesReadableSlate(t *testing.T) {
+	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
+	se := NewUpstreamStatusError(555)
+
+	img := g.render(se)
+
+	bounds := img.Bounds()
+	if bounds.Dx() != 1280 || bounds.Dy() != 720 {
+		t.Fatalf("slate is %dx%d, want 1280x720", bounds.Dx(), bounds.Dy())
+	}
+
+	// Text must actually be drawn: count pixels that differ from the background.
+	var lit int
+	for y := range bounds.Dy() {
+		for x := range bounds.Dx() {
+			if img.RGBAAt(x, y) != slateBackground {
+				lit++
+			}
+		}
+	}
+	if lit == 0 {
+		t.Fatal("slate is entirely background - no text or rule was drawn")
+	}
+	// Guard against a runaway fill that would render a solid block.
+	if lit > bounds.Dx()*bounds.Dy()/2 {
+		t.Errorf("slate is %d/%d pixels lit, which is not text", lit, bounds.Dx()*bounds.Dy())
+	}
+}
+
+func TestNewErrorSlateGeneratorAppliesDefaults(t *testing.T) {
+	g := NewErrorSlateGenerator(ErrorSlateConfig{}, nil)
+	d := DefaultErrorSlateConfig()
+
+	if g.config.Width != d.Width || g.config.Height != d.Height {
+		t.Errorf("size = %dx%d, want %dx%d", g.config.Width, g.config.Height, d.Width, d.Height)
+	}
+	if g.config.FFmpegPath == "" || g.config.Scale <= 0 || g.config.FrameRate <= 0 {
+		t.Errorf("zero-value config not defaulted: %+v", g.config)
+	}
+}
+
+func TestSlateRejectsVariantWithNoEncoder(t *testing.T) {
+	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
+
+	// The shipped FFmpeg build has neither libaom-av1 nor libsvtav1, so an AV1
+	// client must fall back to the embedded static placeholder rather than
+	// silently receive nothing.
+	_, err := g.Slate(context.Background(), NewCodecVariant("av1", "opus"), NewUpstreamStatusError(555))
+	if !errors.Is(err, ErrGeneratorNoEncoder) {
+		t.Errorf("err = %v, want ErrGeneratorNoEncoder", err)
+	}
+}
+
+func TestSlateRejectsNilError(t *testing.T) {
+	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
+	if _, err := g.Slate(context.Background(), NewCodecVariant("h264", "aac"), nil); err == nil {
+		t.Error("expected an error for a nil StreamError")
+	}
+}
+
+func TestInjectErrorSlateKeepsTimestampsMonotonic(t *testing.T) {
+	variant := newTestESVariant(t)
+
+	slate := &CachedPlaceholder{
+		VideoSamples: []ESSample{
+			{PTS: 0, DTS: 0, Data: []byte{0x01}, IsKeyframe: true},
+			{PTS: 3600, DTS: 3600, Data: []byte{0x02}},
+		},
+		AudioSamples: []ESSample{{PTS: 0, DTS: 0, Data: []byte{0x03}}},
+		Duration:     time.Second,
+	}
+
+	// Start from a non-zero PTS, as happens when a live stream fails partway in.
+	const startPTS = int64(1_000_000)
+
+	next := InjectErrorSlate(variant, slate, startPTS, 3*time.Second)
+
+	if next <= startPTS {
+		t.Fatalf("next PTS %d did not advance past start %d", next, startPTS)
+	}
+
+	samples := variant.VideoTrack().ReadFrom(0, 1000)
+	if len(samples) == 0 {
+		t.Fatal("no video samples were injected")
+	}
+
+	var prev int64 = -1
+	for i, s := range samples {
+		if s.PTS < startPTS {
+			t.Errorf("sample %d has PTS %d, before the start PTS %d - clients treat this as a discontinuity", i, s.PTS, startPTS)
+		}
+		if s.PTS < prev {
+			t.Errorf("sample %d PTS %d went backwards from %d", i, s.PTS, prev)
+		}
+		prev = s.PTS
+	}
+}
+
+func TestInjectErrorSlateHandlesNilInputs(t *testing.T) {
+	variant := newTestESVariant(t)
+
+	if got := InjectErrorSlate(nil, nil, 42, time.Second); got != 42 {
+		t.Errorf("nil variant: got %d, want 42", got)
+	}
+	if got := InjectErrorSlate(variant, nil, 42, time.Second); got != 42 {
+		t.Errorf("nil slate: got %d, want 42", got)
+	}
+	empty := &CachedPlaceholder{Duration: time.Second}
+	if got := InjectErrorSlate(variant, empty, 42, time.Second); got != 42 {
+		t.Errorf("empty slate: got %d, want 42", got)
+	}
+}
+
+func TestInjectErrorSlateDoesNotOverwriteLiveInitData(t *testing.T) {
+	variant := newTestESVariant(t)
+
+	live := []byte{0xde, 0xad, 0xbe, 0xef}
+	variant.VideoTrack().SetInitData(live)
+
+	slate := &CachedPlaceholder{
+		VideoSamples:  []ESSample{{PTS: 0, Data: []byte{0x01}, IsKeyframe: true}},
+		VideoInitData: []byte{0x00, 0x11},
+		Duration:      time.Second,
+	}
+	InjectErrorSlate(variant, slate, 0, time.Second)
+
+	got := variant.VideoTrack().GetInitData()
+	if string(got) != string(live) {
+		// Replacing SPS/PPS mid-stream reconfigures the decoder under a client
+		// that is already decoding, which is exactly the failure this avoids.
+		t.Errorf("init data = %v, want the live data %v", got, live)
+	}
+}
+
+// TestSlateEndToEnd encodes a real slate when ffmpeg is present, covering the
+// rasterise -> encode -> demux path that unit tests cannot reach.
+func TestSlateEndToEnd(t *testing.T) {
+	path, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not available")
+	}
+
+	cfg := DefaultErrorSlateConfig()
+	cfg.FFmpegPath = path
+	// Keep the encode small so this stays a fast test.
+	cfg.Width, cfg.Height = 320, 180
+	cfg.Duration = 0.5
+	cfg.FrameRate = 5
+	cfg.Scale = 1
+
+	g := NewErrorSlateGenerator(cfg, nil)
+	variant := NewCodecVariant("h264", "aac")
+	se := NewUpstreamStatusError(555)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	slate, err := g.Slate(ctx, variant, se)
+	if err != nil {
+		t.Fatalf("Slate() failed: %v", err)
+	}
+	if len(slate.VideoSamples) == 0 {
+		t.Error("no video samples were produced")
+	}
+
+	// A second call must hit the cache rather than re-encoding.
+	start := time.Now()
+	again, err := g.Slate(ctx, variant, se)
+	if err != nil {
+		t.Fatalf("cached Slate() failed: %v", err)
+	}
+	if again != slate {
+		t.Error("second call re-encoded instead of using the cache")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("cached lookup took %v, cache is not working", elapsed)
+	}
+}

--- a/internal/relay/error_slate_test.go
+++ b/internal/relay/error_slate_test.go
@@ -194,7 +194,7 @@ func TestRenderProducesReadableSlate(t *testing.T) {
 	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
 	se := NewUpstreamStatusError(555)
 
-	img := g.render(se)
+	img := g.render(se, SlateSize{})
 
 	bounds := img.Bounds()
 	if bounds.Dx() != 1280 || bounds.Dy() != 720 {
@@ -237,7 +237,7 @@ func TestSlateRejectsVariantWithNoEncoder(t *testing.T) {
 	// The shipped FFmpeg build has neither libaom-av1 nor libsvtav1, so an AV1
 	// client must fall back to the embedded static placeholder rather than
 	// silently receive nothing.
-	_, err := g.Slate(context.Background(), NewCodecVariant("av1", "opus"), NewUpstreamStatusError(555))
+	_, err := g.Slate(context.Background(), NewCodecVariant("av1", "opus"), NewUpstreamStatusError(555), SlateSize{})
 	if !errors.Is(err, ErrGeneratorNoEncoder) {
 		t.Errorf("err = %v, want ErrGeneratorNoEncoder", err)
 	}
@@ -245,7 +245,7 @@ func TestSlateRejectsVariantWithNoEncoder(t *testing.T) {
 
 func TestSlateRejectsNilError(t *testing.T) {
 	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
-	if _, err := g.Slate(context.Background(), NewCodecVariant("h264", "aac"), nil); err == nil {
+	if _, err := g.Slate(context.Background(), NewCodecVariant("h264", "aac"), nil, SlateSize{}); err == nil {
 		t.Error("expected an error for a nil StreamError")
 	}
 }
@@ -347,7 +347,7 @@ func TestSlateEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	slate, err := g.Slate(ctx, variant, se)
+	slate, err := g.Slate(ctx, variant, se, SlateSize{})
 	if err != nil {
 		t.Fatalf("Slate() failed: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestSlateEndToEnd(t *testing.T) {
 
 	// A second call must hit the cache rather than re-encoding.
 	start := time.Now()
-	again, err := g.Slate(ctx, variant, se)
+	again, err := g.Slate(ctx, variant, se, SlateSize{})
 	if err != nil {
 		t.Fatalf("cached Slate() failed: %v", err)
 	}

--- a/internal/relay/fallback.go
+++ b/internal/relay/fallback.go
@@ -53,6 +53,21 @@ func DefaultFallbackConfig() FallbackConfig {
 	}
 }
 
+const (
+	// DefaultFallbackErrorThreshold is how many matching upstream errors must be
+	// seen before a session switches to fallback content.
+	DefaultFallbackErrorThreshold = 3
+
+	// DefaultFallbackRecoveryInterval is how long to wait between upstream
+	// recovery probes while in fallback.
+	//
+	// This was previously passed at the call site as the untyped constant 30,
+	// which as a time.Duration is 30 NANOSECONDS. NewFallbackController's
+	// "< 5*time.Second" clamp silently rewrote it to 30s, so the bug never
+	// surfaced -- but the call site read as though it meant seconds and did not.
+	DefaultFallbackRecoveryInterval = 30 * time.Second
+)
+
 // ErrFallbackGenerationFailed is returned when fallback stream generation fails.
 var ErrFallbackGenerationFailed = errors.New("fallback stream generation failed")
 

--- a/internal/relay/manager.go
+++ b/internal/relay/manager.go
@@ -84,6 +84,8 @@ type ManagerConfig struct {
 	ConnectionPoolConfig ConnectionPoolConfig
 	// FallbackConfig for fallback stream generation.
 	FallbackConfig FallbackConfig
+	// ErrorSlateConfig for rendered error slates.
+	ErrorSlateConfig ErrorSlateConfig
 	// HTTPClient for upstream requests.
 	HTTPClient *http.Client
 	// CodecRepo for caching stream codec information.
@@ -134,6 +136,7 @@ func DefaultManagerConfig() ManagerConfig {
 		CircuitBreakerConfig: DefaultCircuitBreakerConfig(),
 		ConnectionPoolConfig: DefaultConnectionPoolConfig(),
 		FallbackConfig:       DefaultFallbackConfig(),
+		ErrorSlateConfig:     DefaultErrorSlateConfig(),
 		// For streaming, we use a transport with connection timeouts but no overall
 		// request timeout. The Timeout field on http.Client applies to the entire
 		// request including reading the body, which would cut off long-running streams.
@@ -177,6 +180,7 @@ type Manager struct {
 	circuitBreakers          *CircuitBreakerRegistry
 	connectionPool           *ConnectionPool
 	fallbackGenerator        *FallbackGenerator
+	errorSlateGenerator      *ErrorSlateGenerator
 	daemonRegistry           *DaemonRegistry
 	daemonStreamMgr          *DaemonStreamManager
 	activeJobMgr             *ActiveJobManager
@@ -237,6 +241,7 @@ func NewManager(config ManagerConfig) *Manager {
 		circuitBreakers:          NewCircuitBreakerRegistry(config.CircuitBreakerConfig),
 		connectionPool:           NewConnectionPool(config.ConnectionPoolConfig),
 		fallbackGenerator:        NewFallbackGenerator(config.FallbackConfig, logger),
+		errorSlateGenerator:      NewErrorSlateGenerator(config.ErrorSlateConfig, logger),
 		daemonRegistry:           config.DaemonRegistry,
 		daemonStreamMgr:          config.DaemonStreamManager,
 		activeJobMgr:             config.ActiveJobManager,
@@ -261,6 +266,11 @@ func (m *Manager) InitializeFallback(ctx context.Context) error {
 // FallbackGenerator returns the manager's fallback generator.
 func (m *Manager) FallbackGenerator() *FallbackGenerator {
 	return m.fallbackGenerator
+}
+
+// ErrorSlateGenerator returns the manager's error slate generator.
+func (m *Manager) ErrorSlateGenerator() *ErrorSlateGenerator {
+	return m.errorSlateGenerator
 }
 
 // DaemonRegistry returns the manager's daemon registry for distributed transcoding.
@@ -893,14 +903,19 @@ func (m *Manager) createSession(ctx context.Context, channelID models.ULID, chan
 	session.lastActivity.Store(time.Now())
 	session.idleSince.Store(time.Time{})
 
+	// Error slates are rendered on demand, so unlike the old FFmpeg-generated
+	// fallback there is nothing to pre-warm and no readiness gate: a session
+	// always gets a generator and always has something to show on failure.
+	session.errorSlateGenerator = m.errorSlateGenerator
+
 	// Initialize fallback controller if fallback generator is ready
 	// Note: Fallback settings are now managed at the manager level, not profile level
 	if m.fallbackGenerator != nil && m.fallbackGenerator.IsReady() {
 		session.fallbackGenerator = m.fallbackGenerator
 		session.fallbackController = NewFallbackController(
 			m.fallbackGenerator,
-			3,  // Default error threshold
-			30, // Default recovery interval in seconds
+			DefaultFallbackErrorThreshold,
+			DefaultFallbackRecoveryInterval,
 			m.logger.With(slog.String("session_id", session.ID.String())),
 		)
 	}

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -211,6 +211,9 @@ type RelaySession struct {
 	// slatePTS is the next PTS to write slate samples at, kept monotonic across
 	// refills so clients never see time run backwards.
 	slatePTS atomic.Int64
+	// livePTSRebase, when non-zero, is the PTS the resumed origin stream is
+	// shifted onto after a slate, so live picks up where the slate stopped.
+	livePTSRebase atomic.Int64
 
 	// Multi-format streaming support
 	formatRouter    *FormatRouter          // Routes requests to appropriate output handler
@@ -429,6 +432,45 @@ func (s *RelaySession) logPipelineDecision() {
 	slog.Info("Starting relay pipeline", logFields...)
 }
 
+// liveVideoSize reports the resolution the live stream is actually coding at.
+//
+// It reads the SPS out of recent keyframe samples rather than the track's init
+// data, because the MPEG-TS path sets video init data to nil -- SetVideoCodec
+// ("h264", nil) -- and carries parameter sets inline in each keyframe instead.
+// Reading init data here would always come back empty on a live stream.
+//
+// Returns ok=false before any keyframe has arrived, where the slate is free to
+// pick its own size because there is no live raster to match.
+func (s *RelaySession) liveVideoSize(variant *ESVariant) (SlateSize, bool) {
+	if variant == nil {
+		return SlateSize{}, false
+	}
+
+	videoCodec := variant.Variant().VideoCodec()
+
+	// Keyframes carry the parameter sets; scan back from the newest so a
+	// mid-stream resolution change is picked up rather than the opening one.
+	samples := variant.VideoTrack().ReadFromKeyframe(0, liveSPSScanSamples)
+	for i := len(samples) - 1; i >= 0; i-- {
+		if !samples[i].IsKeyframe {
+			continue
+		}
+		if size, ok := spsSizeFromAnnexB(samples[i].Data, videoCodec); ok {
+			return size, true
+		}
+	}
+
+	return SlateSize{}, false
+}
+
+// liveSPSScanSamples bounds how far back to look for a parameter set.
+const liveSPSScanSamples = 256
+
+// slatePTSGap is the 90kHz gap left between the live stream and spliced slate
+// content, and again on the way back. One frame at 25fps: enough that the two
+// timelines never collide, small enough to be invisible.
+const slatePTSGap = 3600
+
 // slateVariant picks the codec variant to render the error slate in.
 //
 // When the origin failed before any codec was detected -- the common case, since
@@ -473,15 +515,6 @@ func (s *RelaySession) serveErrorSlate(cause error) (recovered bool, err error) 
 
 	variant := s.slateVariant()
 
-	slate, err := s.errorSlateGenerator.Slate(s.ctx, variant, streamErr)
-	if err != nil {
-		slog.Warn("Could not render error slate",
-			slog.String("session_id", s.ID.String()),
-			slog.String("variant", variant.String()),
-			slog.String("error", err.Error()))
-		return false, err
-	}
-
 	// Publishing the variant as the source unblocks the processors already
 	// waiting on WaitSourceVariant, so the existing output path serves the slate
 	// without needing a parallel one per container format.
@@ -493,10 +526,32 @@ func (s *RelaySession) serveErrorSlate(cause error) (recovered bool, err error) 
 		return false, errors.New("could not obtain a variant for the slate")
 	}
 
+	// Match the live raster when there is one, so the slate's slices agree with
+	// the parameter sets the track already published.
+	size, matched := s.liveVideoSize(esVariant)
+
+	// Continue the live timeline instead of restarting it. Without this the
+	// slate would splice in at PTS 0 behind a stream already minutes in, and
+	// decoders treat a backwards jump as a discontinuity and drop the stream.
+	if latest := esVariant.VideoTrack().LatestPTS(); latest > s.slatePTS.Load() {
+		s.slatePTS.Store(latest + slatePTSGap)
+	}
+
+	slate, err := s.errorSlateGenerator.Slate(s.ctx, variant, streamErr, size)
+	if err != nil {
+		slog.Warn("Could not render error slate",
+			slog.String("session_id", s.ID.String()),
+			slog.String("variant", variant.String()),
+			slog.String("error", err.Error()))
+		return false, err
+	}
+
 	slog.Info("Serving error slate",
 		slog.String("session_id", s.ID.String()),
 		slog.String("channel", s.ChannelName),
 		slog.String("variant", variant.String()),
+		slog.Bool("matched_live_resolution", matched),
+		slog.Int64("splice_pts", s.slatePTS.Load()),
 		slog.String("kind", string(streamErr.Kind)),
 		slog.String("headline", streamErr.Headline),
 		slog.String("detail", streamErr.Detail))
@@ -529,9 +584,15 @@ func (s *RelaySession) serveErrorSlate(cause error) (recovered bool, err error) 
 			if !s.testUpstreamRecovery() {
 				continue
 			}
+			// The resumed origin restarts on its own timeline, which has no
+			// relation to where the slate ended. Rebase it onto the slate's end
+			// so the return to live is as seamless as the switch away from it.
+			s.livePTSRebase.Store(s.slatePTS.Load() + slatePTSGap)
+
 			slog.Info("Origin recovered while showing error slate",
 				slog.String("session_id", s.ID.String()),
-				slog.String("channel", s.ChannelName))
+				slog.String("channel", s.ChannelName),
+				slog.Int64("live_rebase_pts", s.livePTSRebase.Load()))
 			s.slateErr.Store(nil)
 			return true, nil
 		}
@@ -684,6 +745,8 @@ func (s *RelaySession) runHLSCollapsePipeline() error {
 	if s.CachedCodecInfo != nil && s.CachedCodecInfo.AudioCodec != "" {
 		demuxerConfig.ProbeOverrideAudioCodec = s.CachedCodecInfo.AudioCodec
 	}
+	// Resuming after an error slate: shift the origin onto the slate's timeline.
+	demuxerConfig.PTSRebaseTarget = s.livePTSRebase.Swap(0)
 	s.tsDemuxer = NewTSDemuxer(s.esBuffer, demuxerConfig)
 
 	// Use HLS config from manager for segment settings
@@ -884,6 +947,8 @@ func (s *RelaySession) runESPipeline() error {
 	if s.CachedCodecInfo != nil && s.CachedCodecInfo.AudioCodec != "" {
 		demuxerConfig.ProbeOverrideAudioCodec = s.CachedCodecInfo.AudioCodec
 	}
+	// Resuming after an error slate: shift the origin onto the slate's timeline.
+	demuxerConfig.PTSRebaseTarget = s.livePTSRebase.Swap(0)
 	s.tsDemuxer = NewTSDemuxer(s.esBuffer, demuxerConfig)
 
 	// Determine the source URL

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -204,6 +204,14 @@ type RelaySession struct {
 	fallbackController *FallbackController
 	fallbackGenerator  *FallbackGenerator
 
+	// errorSlateGenerator renders viewer-facing slates for pipeline failures.
+	errorSlateGenerator *ErrorSlateGenerator
+	// slateErr holds the classified error currently being shown as a slate.
+	slateErr atomic.Pointer[StreamError]
+	// slatePTS is the next PTS to write slate samples at, kept monotonic across
+	// refills so clients never see time run backwards.
+	slatePTS atomic.Int64
+
 	// Multi-format streaming support
 	formatRouter    *FormatRouter          // Routes requests to appropriate output handler
 	containerFormat models.ContainerFormat // Current container format
@@ -303,6 +311,27 @@ func (s *RelaySession) runPipeline() {
 			}
 		}
 
+		// Otherwise show the viewer what went wrong rather than dropping them
+		// into a dead stream. Unlike the FFmpeg fallback above this needs no
+		// pre-warming and no error-pattern match, so it is the path that
+		// actually runs for upstream failures.
+		if err != nil && !errors.Is(err, context.Canceled) {
+			recovered, slateErr := s.serveErrorSlate(err)
+			if slateErr == nil {
+				s.manager.circuitBreakers.Get(s.StreamURL).RecordFailure()
+				if recovered {
+					// The origin came back while the viewer was watching the
+					// slate. Retry the live pipeline rather than ending here, so
+					// the channel resumes without the viewer touching anything.
+					err = nil
+					continue
+				}
+				// Slate ran until the client left or the session was closed.
+				err = nil
+				return
+			}
+		}
+
 		// No error or no fallback configured - exit
 		if err != nil {
 			cb := s.manager.circuitBreakers.Get(s.StreamURL)
@@ -398,6 +427,115 @@ func (s *RelaySession) logPipelineDecision() {
 	}
 
 	slog.Info("Starting relay pipeline", logFields...)
+}
+
+// slateVariant picks the codec variant to render the error slate in.
+//
+// When the origin failed before any codec was detected -- the common case, since
+// an HTTP refusal happens before a single TS packet arrives -- there is no source
+// variant to copy, so the client's negotiated target codecs are used instead.
+// Those are what the client asked for, so they are what it can decode.
+func (s *RelaySession) slateVariant() CodecVariant {
+	if s.esBuffer != nil {
+		if v := s.esBuffer.GetSourceVariant(); v != nil {
+			return v.Variant()
+		}
+	}
+
+	videoCodec, audioCodec := "h264", "aac"
+	if s.EncodingProfile != nil {
+		if c := string(s.EncodingProfile.TargetVideoCodec); c != "" {
+			videoCodec = c
+		}
+		if c := string(s.EncodingProfile.TargetAudioCodec); c != "" {
+			audioCodec = c
+		}
+	}
+	return NewCodecVariant(videoCodec, audioCodec)
+}
+
+// serveErrorSlate renders the failure as a looping video slate and feeds it to
+// connected clients until the context is cancelled or the origin recovers.
+//
+// It returns recovered=true when the origin came back and the caller should
+// resume the live pipeline. A non-nil error means no slate could be produced, in
+// which case the caller falls back to failing the session as before.
+func (s *RelaySession) serveErrorSlate(cause error) (recovered bool, err error) {
+	if s.errorSlateGenerator == nil {
+		return false, errors.New("no error slate generator configured")
+	}
+	if s.esBuffer == nil {
+		return false, errors.New("no ES buffer to inject a slate into")
+	}
+
+	streamErr := ClassifyStreamError(cause)
+	s.slateErr.Store(streamErr)
+
+	variant := s.slateVariant()
+
+	slate, err := s.errorSlateGenerator.Slate(s.ctx, variant, streamErr)
+	if err != nil {
+		slog.Warn("Could not render error slate",
+			slog.String("session_id", s.ID.String()),
+			slog.String("variant", variant.String()),
+			slog.String("error", err.Error()))
+		return false, err
+	}
+
+	// Publishing the variant as the source unblocks the processors already
+	// waiting on WaitSourceVariant, so the existing output path serves the slate
+	// without needing a parallel one per container format.
+	esVariant := s.esBuffer.GetSourceVariant()
+	if esVariant == nil {
+		esVariant = s.esBuffer.CreateSourceVariant(variant.VideoCodec(), variant.AudioCodec())
+	}
+	if esVariant == nil {
+		return false, errors.New("could not obtain a variant for the slate")
+	}
+
+	slog.Info("Serving error slate",
+		slog.String("session_id", s.ID.String()),
+		slog.String("channel", s.ChannelName),
+		slog.String("variant", variant.String()),
+		slog.String("kind", string(streamErr.Kind)),
+		slog.String("headline", streamErr.Headline),
+		slog.String("detail", streamErr.Detail))
+
+	s.inFallback.Store(true)
+	defer s.inFallback.Store(false)
+
+	// Keep roughly this much slate buffered ahead of the client at all times.
+	const slateLead = 6 * time.Second
+
+	refill := time.NewTicker(slate.Duration)
+	defer refill.Stop()
+
+	recovery := time.NewTicker(DefaultFallbackRecoveryInterval)
+	defer recovery.Stop()
+
+	s.slatePTS.Store(InjectErrorSlate(esVariant, slate, s.slatePTS.Load(), slateLead))
+	s.lastActivity.Store(time.Now())
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return false, nil
+
+		case <-refill.C:
+			s.slatePTS.Store(InjectErrorSlate(esVariant, slate, s.slatePTS.Load(), slate.Duration))
+			s.lastActivity.Store(time.Now())
+
+		case <-recovery.C:
+			if !s.testUpstreamRecovery() {
+				continue
+			}
+			slog.Info("Origin recovered while showing error slate",
+				slog.String("session_id", s.ID.String()),
+				slog.String("channel", s.ChannelName))
+			s.slateErr.Store(nil)
+			return true, nil
+		}
+	}
 }
 
 // runFallbackStream runs the fallback stream until recovery or cancellation.
@@ -894,18 +1032,24 @@ func (s *RelaySession) runIngestLoop(inputURL string, demuxer *TSDemuxer) error 
 
 	resp, err := s.manager.config.HTTPClient.Do(req)
 	if err != nil {
+		streamErr := ClassifyStreamError(err)
 		slog.Error("Ingest loop: HTTP request failed",
 			slog.String("session_id", s.ID.String()),
-			slog.String("error", err.Error()))
-		return err
+			slog.String("error", err.Error()),
+			slog.String("kind", string(streamErr.Kind)),
+			slog.String("headline", streamErr.Headline))
+		return streamErr
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		streamErr := NewUpstreamStatusError(resp.StatusCode)
 		slog.Error("Ingest loop: upstream returned non-200 status",
 			slog.String("session_id", s.ID.String()),
-			slog.Int("status", resp.StatusCode))
-		return fmt.Errorf("upstream returned HTTP %d", resp.StatusCode)
+			slog.Int("status", resp.StatusCode),
+			slog.String("kind", string(streamErr.Kind)),
+			slog.String("headline", streamErr.Headline))
+		return streamErr
 	}
 
 	// Log upstream response headers for debugging stream termination issues

--- a/internal/relay/shared_buffer.go
+++ b/internal/relay/shared_buffer.go
@@ -318,6 +318,22 @@ func (t *ESTrack) ReadFromKeyframe(afterSeq uint64, maxSamples int) []ESSample {
 	return t.collectSamplesLocked(startIdx, maxSamples)
 }
 
+// LatestPTS returns the presentation timestamp of the most recent sample, or 0
+// when the track is empty.
+//
+// Needed when splicing synthetic content onto a live track: the new samples must
+// continue from where the live stream stopped, not restart at zero, or decoders
+// see time run backwards and drop the stream.
+func (t *ESTrack) LatestPTS() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if len(t.samples) == 0 {
+		return 0
+	}
+	return t.samples[len(t.samples)-1].PTS
+}
+
 // LastSequence returns the sequence number of the most recent sample.
 func (t *ESTrack) LastSequence() uint64 {
 	t.mu.RLock()

--- a/internal/relay/ts_demuxer.go
+++ b/internal/relay/ts_demuxer.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
@@ -31,6 +32,16 @@ type TSDemuxerConfig struct {
 	// This is used when encountering unsupported audio tracks.
 	ProbeOverrideAudioCodec string
 
+	// PTSRebaseTarget, when non-zero, shifts the whole stream so its first
+	// sample lands on this PTS.
+	//
+	// Used when resuming a live origin after an error slate: the origin restarts
+	// on its own timeline, which bears no relation to where the slate stopped, so
+	// without a shift the return to live is a backwards jump for the decoder.
+	// The offset is derived from the first sample seen and then held constant, so
+	// the stream's internal timing is untouched.
+	PTSRebaseTarget int64
+
 	// Callbacks for demuxed samples.
 	OnVideoSample func(pts, dts int64, data []byte, isKeyframe bool)
 	OnAudioSample func(pts int64, data []byte)
@@ -40,6 +51,11 @@ type TSDemuxerConfig struct {
 type TSDemuxer struct {
 	config TSDemuxerConfig
 	buffer *SharedESBuffer
+
+	// ptsOffset is applied to every emitted sample; resolved from the first
+	// sample when PTSRebaseTarget is set.
+	ptsOffset     atomic.Int64
+	ptsOffsetOnce sync.Once
 
 	// mediacommon reader
 	reader *mpegts.Reader
@@ -539,7 +555,25 @@ func (d *TSDemuxer) handleOpus(pts int64, packets [][]byte) error {
 }
 
 // emitVideoSample writes a video sample to the buffer and/or callback.
+// rebase resolves the rebase offset from the first sample seen and applies it.
+func (d *TSDemuxer) rebase(pts, dts int64) (int64, int64) {
+	if d.config.PTSRebaseTarget == 0 {
+		return pts, dts
+	}
+	d.ptsOffsetOnce.Do(func() {
+		d.ptsOffset.Store(d.config.PTSRebaseTarget - pts)
+		d.config.Logger.Info("Rebasing resumed stream onto the slate timeline",
+			slog.Int64("first_pts", pts),
+			slog.Int64("target_pts", d.config.PTSRebaseTarget),
+			slog.Int64("offset", d.ptsOffset.Load()))
+	})
+	off := d.ptsOffset.Load()
+	return pts + off, dts + off
+}
+
 func (d *TSDemuxer) emitVideoSample(pts, dts int64, data []byte, isKeyframe bool) {
+	pts, dts = d.rebase(pts, dts)
+
 	// Trace: Log keyframe detection (very verbose)
 	if isKeyframe {
 		d.config.Logger.Log(context.Background(), observability.LevelTrace, "Keyframe detected in demuxer",
@@ -566,6 +600,8 @@ func (d *TSDemuxer) emitVideoSample(pts, dts int64, data []byte, isKeyframe bool
 
 // emitAudioSample writes an audio sample to the buffer and/or callback.
 func (d *TSDemuxer) emitAudioSample(pts int64, data []byte) {
+	pts, _ = d.rebase(pts, pts)
+
 	// Write to buffer
 	if d.buffer != nil {
 		if d.config.TargetVariant != "" {

--- a/internal/repository/epg_program_repo.go
+++ b/internal/repository/epg_program_repo.go
@@ -185,55 +185,86 @@ func (r *epgProgramRepo) Delete(ctx context.Context, id models.ULID) error {
 	return nil
 }
 
+// epgProgramDeleteBatch bounds how many programs a single DELETE removes.
+//
+// Each statement takes SQLite's write lock for its duration, so the batch size
+// trades total throughput against how long anything else -- an ingestion, a
+// stream lookup -- is blocked behind it.
+const epgProgramDeleteBatch = 5000
+
 // DeleteBySourceID hard-deletes all programs for a source.
-// Uses Unscoped() for permanent deletion since EPG programs are fully replaced on each ingestion.
-// Deletes in batches by channel to reduce lock duration and prevent SQLite BUSY errors.
+// Uses Unscoped() for permanent deletion since EPG programs are fully replaced
+// on each ingestion.
+//
+// Deletes in bounded batches keyed on the primary key. The previous
+// implementation first ran SELECT DISTINCT channel_id across every program row
+// for the source, purely to group the deletes by channel: on a source with over
+// a million programs that scan alone outlasted the HTTP request that triggered
+// it, and the caller saw a timeout before a single row had been removed.
+// Batching on the primary key needs no such pre-pass, and each statement holds
+// the write lock only briefly.
 func (r *epgProgramRepo) DeleteBySourceID(ctx context.Context, sourceID models.ULID) error {
-	// Get distinct channel IDs for this source to batch delete by channel
-	var channelIDs []string
-	if err := r.db.WithContext(ctx).
-		Model(&models.EpgProgram{}).
-		Where("source_id = ?", sourceID).
-		Distinct("channel_id").
-		Pluck("channel_id", &channelIDs).Error; err != nil {
-		return fmt.Errorf("fetching channel IDs for deletion: %w", err)
-	}
+	var total int64
 
-	if len(channelIDs) == 0 {
-		// No programs to delete
-		return nil
-	}
-
-	// Delete in batches of channels (e.g., 50 channels at a time)
-	// This balances transaction size with number of transactions
-	const channelBatchSize = 50
-	totalDeleted := int64(0)
-
-	for i := 0; i < len(channelIDs); i += channelBatchSize {
-		end := i + channelBatchSize
-		if end > len(channelIDs) {
-			end = len(channelIDs)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		channelBatch := channelIDs[i:end]
 
-		// Delete all programs for this batch of channels
+		ids := r.db.Model(&models.EpgProgram{}).
+			Select("id").
+			Where("source_id = ?", sourceID).
+			Limit(epgProgramDeleteBatch)
+
 		result := r.db.WithContext(ctx).Unscoped().
-			Where("source_id = ? AND channel_id IN ?", sourceID, channelBatch).
+			Where("id IN (?)", ids).
 			Delete(&models.EpgProgram{})
-
 		if result.Error != nil {
-			return fmt.Errorf("deleting EPG programs (batch %d-%d of %d channels): %w",
-				i, end, len(channelIDs), result.Error)
+			return fmt.Errorf("deleting EPG programs for source %s after %d rows: %w",
+				sourceID, total, result.Error)
 		}
-		totalDeleted += result.RowsAffected
 
-		// Check for context cancellation between batches
-		if ctx.Err() != nil {
-			return ctx.Err()
+		total += result.RowsAffected
+		if result.RowsAffected == 0 {
+			return nil
 		}
 	}
+}
 
-	return nil
+// DeleteOrphaned removes programs whose source no longer exists, returning how
+// many rows were deleted.
+//
+// Source deletion removes the source row first so the UI responds immediately,
+// then sweeps the programs in the background. If the process stops mid-sweep the
+// remaining programs have no source, are unreachable through any query, and
+// would otherwise sit in the database forever. This reclaims them.
+func (r *epgProgramRepo) DeleteOrphaned(ctx context.Context) (int64, error) {
+	var total int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+
+		liveSources := r.db.Model(&models.EpgSource{}).Select("id")
+
+		ids := r.db.Model(&models.EpgProgram{}).
+			Select("id").
+			Where("source_id NOT IN (?)", liveSources).
+			Limit(epgProgramDeleteBatch)
+
+		result := r.db.WithContext(ctx).Unscoped().
+			Where("id IN (?)", ids).
+			Delete(&models.EpgProgram{})
+		if result.Error != nil {
+			return total, fmt.Errorf("deleting orphaned EPG programs after %d rows: %w", total, result.Error)
+		}
+
+		total += result.RowsAffected
+		if result.RowsAffected == 0 {
+			return total, nil
+		}
+	}
 }
 
 // DeleteStaleBySourceID deletes programs for a source that haven't been updated since the given time.

--- a/internal/repository/epg_program_repo_test.go
+++ b/internal/repository/epg_program_repo_test.go
@@ -506,3 +506,116 @@ func TestEpgProgramRepo_CreateInBatches(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), count)
 }
+
+// TestEpgProgramRepo_DeleteBySourceID_LargeSource exercises the batching path.
+// The old implementation ran SELECT DISTINCT channel_id over every row for the
+// source before deleting anything, which on a real source of over a million
+// programs outlasted the HTTP request that triggered it.
+func TestEpgProgramRepo_DeleteBySourceID_LargeSource(t *testing.T) {
+	db := setupEpgProgramTestDB(t)
+	repo := NewEpgProgramRepository(db)
+	ctx := context.Background()
+
+	target := createTestEpgSource(t, db, "large-epg")
+	keep := createTestEpgSource(t, db, "keep-epg")
+
+	// More rows than one delete batch, so the loop runs more than once.
+	const programCount = epgProgramDeleteBatch + 250
+
+	now := time.Now().Truncate(time.Second)
+	programs := make([]*models.EpgProgram, 0, programCount+10)
+	for i := range programCount {
+		programs = append(programs, &models.EpgProgram{
+			SourceID:  target.ID,
+			ChannelID: "ch." + string(rune('a'+i%26)),
+			Start:     now.Add(time.Duration(i) * time.Minute),
+			Stop:      now.Add(time.Duration(i+1) * time.Minute),
+			Title:     "Programme",
+		})
+	}
+	for i := range 10 {
+		programs = append(programs, &models.EpgProgram{
+			SourceID:  keep.ID,
+			ChannelID: "keep.1",
+			Start:     now.Add(time.Duration(i) * time.Minute),
+			Stop:      now.Add(time.Duration(i+1) * time.Minute),
+			Title:     "Keep me",
+		})
+	}
+	// Insert in chunks: a single CreateBatch of this many rows exceeds SQLite's
+	// bound-variable limit.
+	const insertChunk = 500
+	for i := 0; i < len(programs); i += insertChunk {
+		end := min(i+insertChunk, len(programs))
+		require.NoError(t, repo.CreateBatch(ctx, programs[i:end]))
+	}
+
+	require.NoError(t, repo.DeleteBySourceID(ctx, target.ID))
+
+	gone, err := repo.CountBySourceID(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Zero(t, gone, "programs for the deleted source remain")
+
+	// Deleting one source must not touch another's rows.
+	kept, err := repo.CountBySourceID(ctx, keep.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), kept, "deleting one source removed another source's programs")
+}
+
+// TestEpgProgramRepo_DeleteBySourceID_Cancellation checks the loop honours
+// cancellation: a sweep that cannot be stopped would hold the write lock through
+// shutdown.
+func TestEpgProgramRepo_DeleteBySourceID_Cancellation(t *testing.T) {
+	db := setupEpgProgramTestDB(t)
+	repo := NewEpgProgramRepository(db)
+
+	source := createTestEpgSource(t, db, "cancel-epg")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := repo.DeleteBySourceID(ctx, source.ID)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestEpgProgramRepo_DeleteOrphaned covers recovery from an interrupted sweep:
+// source deletion removes the source row first, so a restart in between leaves
+// programs that nothing queries and nothing else would ever remove.
+func TestEpgProgramRepo_DeleteOrphaned(t *testing.T) {
+	db := setupEpgProgramTestDB(t)
+	repo := NewEpgProgramRepository(db)
+	ctx := context.Background()
+
+	live := createTestEpgSource(t, db, "live-epg")
+	doomed := createTestEpgSource(t, db, "doomed-epg")
+
+	now := time.Now().Truncate(time.Second)
+	var programs []*models.EpgProgram
+	for i := range 5 {
+		programs = append(programs,
+			&models.EpgProgram{
+				SourceID: live.ID, ChannelID: "live.1",
+				Start: now.Add(time.Duration(i) * time.Minute),
+				Stop:  now.Add(time.Duration(i+1) * time.Minute),
+				Title: "Live",
+			},
+			&models.EpgProgram{
+				SourceID: doomed.ID, ChannelID: "doomed.1",
+				Start: now.Add(time.Duration(i) * time.Minute),
+				Stop:  now.Add(time.Duration(i+1) * time.Minute),
+				Title: "Orphan",
+			})
+	}
+	require.NoError(t, repo.CreateBatch(ctx, programs))
+
+	// Simulate the source row going first, then the process stopping.
+	require.NoError(t, db.Unscoped().Delete(&models.EpgSource{}, "id = ?", doomed.ID).Error)
+
+	deleted, err := repo.DeleteOrphaned(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), deleted)
+
+	remaining, err := repo.CountBySourceID(ctx, live.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), remaining, "the live source's programs were swept as orphans")
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -145,6 +145,8 @@ type EpgProgramRepository interface {
 	Delete(ctx context.Context, id models.ULID) error
 	// DeleteBySourceID deletes all programs for a source (used when deleting the source itself).
 	DeleteBySourceID(ctx context.Context, sourceID models.ULID) error
+	// DeleteOrphaned removes programs whose source no longer exists, returning the row count.
+	DeleteOrphaned(ctx context.Context) (int64, error)
 	// DeleteStaleBySourceID deletes programs not updated since the given time (used during ingestion cleanup).
 	DeleteStaleBySourceID(ctx context.Context, sourceID models.ULID, olderThan time.Time) (int64, error)
 	// DeleteExpired deletes programs that ended before the given time.

--- a/internal/service/epg_service.go
+++ b/internal/service/epg_service.go
@@ -13,6 +13,11 @@ import (
 	"github.com/jmylchreest/tvarr/internal/service/progress"
 )
 
+// epgProgramSweepTimeout bounds a background program sweep. Generous, because
+// it is deleting millions of rows in batches behind a shared write lock, but
+// finite so a wedged sweep cannot hold resources for the process's lifetime.
+const epgProgramSweepTimeout = 30 * time.Minute
+
 // EpgService provides business logic for EPG source management.
 type EpgService struct {
 	epgSourceRepo   repository.EpgSourceRepository
@@ -167,18 +172,66 @@ func (s *EpgService) Update(ctx context.Context, source *models.EpgSource) error
 }
 
 // Delete deletes an EPG source and all its programs.
+// Delete removes an EPG source and all of its programs.
+//
+// The source row goes first and the programs are swept in the background,
+// because a mature source holds millions of program rows and removing them takes
+// far longer than any HTTP client will wait -- deleting them inline returned a
+// request timeout to the user while the delete was still running, leaving them
+// no way to tell whether it had worked.
+//
+// Removing the source first is deliberate: it is a single row, so it is instant,
+// and once it is gone the source is absent from the UI and cannot be ingested
+// again. The programs left behind are unreachable through any query, and
+// SweepOrphanedPrograms reclaims them if this process stops mid-sweep.
 func (s *EpgService) Delete(ctx context.Context, id models.ULID) error {
-	// First delete all programs for this source
-	if err := s.epgProgramRepo.DeleteBySourceID(ctx, id); err != nil {
-		return fmt.Errorf("deleting programs: %w", err)
-	}
-
-	// Then delete the source
 	if err := s.epgSourceRepo.Delete(ctx, id); err != nil {
 		return fmt.Errorf("deleting EPG source: %w", err)
 	}
 
-	s.logger.Info("deleted EPG source", "id", id.String())
+	s.logger.Info("deleted EPG source, sweeping its programs in the background",
+		"id", id.String())
+
+	go func() {
+		// Detached from the request context, which is cancelled the moment the
+		// response is written and would abort the sweep immediately.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), epgProgramSweepTimeout)
+		defer cancel()
+
+		started := time.Now()
+		if err := s.epgProgramRepo.DeleteBySourceID(ctx, id); err != nil {
+			// Not fatal: the rows are orphaned, and the next startup sweep
+			// reclaims them.
+			s.logger.Error("sweeping programs for deleted EPG source failed; orphans will be reclaimed on next startup",
+				"id", id.String(),
+				"elapsed", time.Since(started),
+				"error", err)
+			return
+		}
+
+		s.logger.Info("swept programs for deleted EPG source",
+			"id", id.String(),
+			"elapsed", time.Since(started))
+	}()
+
+	return nil
+}
+
+// SweepOrphanedPrograms removes programs left behind by a source deletion that
+// did not finish. Intended to be called once at startup.
+func (s *EpgService) SweepOrphanedPrograms(ctx context.Context) error {
+	started := time.Now()
+
+	deleted, err := s.epgProgramRepo.DeleteOrphaned(ctx)
+	if err != nil {
+		return fmt.Errorf("sweeping orphaned EPG programs: %w", err)
+	}
+
+	if deleted > 0 {
+		s.logger.Info("reclaimed orphaned EPG programs",
+			"count", deleted,
+			"elapsed", time.Since(started))
+	}
 
 	return nil
 }

--- a/internal/service/epg_service_test.go
+++ b/internal/service/epg_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -120,21 +121,31 @@ func (m *mockEpgSourceRepo) GetByURL(ctx context.Context, url string) (*models.E
 
 // Mock EPG Program Repository
 type mockEpgProgramRepo struct {
+	// mu guards programs: source deletion now sweeps them on a background
+	// goroutine, so tests and the sweep touch this map concurrently.
+	mu             sync.Mutex
 	programs       map[models.ULID]*models.EpgProgram
 	createErr      error
 	createBatchErr error
 	deleteErr      error
 	countBySource  map[models.ULID]int64
+	// knownSources marks which sources still exist, so DeleteOrphaned can tell
+	// an orphan from a live program.
+	knownSources map[models.ULID]bool
 }
 
 func newMockEpgProgramRepo() *mockEpgProgramRepo {
 	return &mockEpgProgramRepo{
 		programs:      make(map[models.ULID]*models.EpgProgram),
+		knownSources:  make(map[models.ULID]bool),
 		countBySource: make(map[models.ULID]int64),
 	}
 }
 
 func (m *mockEpgProgramRepo) Create(ctx context.Context, program *models.EpgProgram) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.createErr != nil {
 		return m.createErr
 	}
@@ -147,6 +158,9 @@ func (m *mockEpgProgramRepo) Create(ctx context.Context, program *models.EpgProg
 }
 
 func (m *mockEpgProgramRepo) CreateBatch(ctx context.Context, programs []*models.EpgProgram) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.createBatchErr != nil {
 		return m.createBatchErr
 	}
@@ -161,6 +175,9 @@ func (m *mockEpgProgramRepo) CreateBatch(ctx context.Context, programs []*models
 }
 
 func (m *mockEpgProgramRepo) GetByID(ctx context.Context, id models.ULID) (*models.EpgProgram, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	program, ok := m.programs[id]
 	if !ok {
 		return nil, errors.New("not found")
@@ -169,6 +186,9 @@ func (m *mockEpgProgramRepo) GetByID(ctx context.Context, id models.ULID) (*mode
 }
 
 func (m *mockEpgProgramRepo) GetBySourceID(ctx context.Context, sourceID models.ULID, callback func(*models.EpgProgram) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	for _, p := range m.programs {
 		if p.SourceID == sourceID {
 			if err := callback(p); err != nil {
@@ -180,6 +200,9 @@ func (m *mockEpgProgramRepo) GetBySourceID(ctx context.Context, sourceID models.
 }
 
 func (m *mockEpgProgramRepo) GetByChannelID(ctx context.Context, channelID string, start, end time.Time) ([]*models.EpgProgram, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	var programs []*models.EpgProgram
 	for _, p := range m.programs {
 		if p.ChannelID == channelID && p.Start.Before(end) && p.Stop.After(start) {
@@ -190,6 +213,9 @@ func (m *mockEpgProgramRepo) GetByChannelID(ctx context.Context, channelID strin
 }
 
 func (m *mockEpgProgramRepo) GetByChannelIDWithLimit(ctx context.Context, channelID string, limit int) ([]*models.EpgProgram, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	var programs []*models.EpgProgram
 	for _, p := range m.programs {
 		if p.ChannelID == channelID {
@@ -203,6 +229,9 @@ func (m *mockEpgProgramRepo) GetByChannelIDWithLimit(ctx context.Context, channe
 }
 
 func (m *mockEpgProgramRepo) GetCurrentByChannelID(ctx context.Context, channelID string) (*models.EpgProgram, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	now := time.Now()
 	for _, p := range m.programs {
 		if p.ChannelID == channelID && p.Start.Before(now) && p.Stop.After(now) {
@@ -213,6 +242,9 @@ func (m *mockEpgProgramRepo) GetCurrentByChannelID(ctx context.Context, channelI
 }
 
 func (m *mockEpgProgramRepo) Delete(ctx context.Context, id models.ULID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -224,6 +256,9 @@ func (m *mockEpgProgramRepo) Delete(ctx context.Context, id models.ULID) error {
 }
 
 func (m *mockEpgProgramRepo) DeleteBySourceID(ctx context.Context, sourceID models.ULID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -237,6 +272,9 @@ func (m *mockEpgProgramRepo) DeleteBySourceID(ctx context.Context, sourceID mode
 }
 
 func (m *mockEpgProgramRepo) DeleteStaleBySourceID(ctx context.Context, sourceID models.ULID, olderThan time.Time) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	var count int64
 	for id, p := range m.programs {
 		if p.SourceID == sourceID && p.UpdatedAt.Before(olderThan) {
@@ -249,6 +287,9 @@ func (m *mockEpgProgramRepo) DeleteStaleBySourceID(ctx context.Context, sourceID
 }
 
 func (m *mockEpgProgramRepo) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	var count int64
 	for id, p := range m.programs {
 		if p.Stop.Before(before) {
@@ -259,11 +300,39 @@ func (m *mockEpgProgramRepo) DeleteExpired(ctx context.Context, before time.Time
 	return count, nil
 }
 
+// DeleteOld delegates to DeleteExpired, which takes the lock itself -- taking it
+// here as well would deadlock on the non-reentrant mutex.
 func (m *mockEpgProgramRepo) DeleteOld(ctx context.Context) (int64, error) {
 	return m.DeleteExpired(ctx, time.Now().Add(-24*time.Hour))
 }
 
+// DeleteOrphaned removes programs whose source is no longer known to the mock.
+func (m *mockEpgProgramRepo) DeleteOrphaned(ctx context.Context) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var deleted int64
+	for id, p := range m.programs {
+		if !m.knownSources[p.SourceID] {
+			delete(m.programs, id)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// countPrograms reports how many programs remain, for assertions against the
+// background sweep.
+func (m *mockEpgProgramRepo) countPrograms() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.programs)
+}
+
 func (m *mockEpgProgramRepo) CountBySourceID(ctx context.Context, sourceID models.ULID) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	return m.countBySource[sourceID], nil
 }
 
@@ -632,4 +701,108 @@ func TestEpgService_CreateXMLTV_NoAutoStreamSource(t *testing.T) {
 	// No stream source should be created
 	streamSources, _ := streamSourceRepo.GetAll(context.Background())
 	assert.Len(t, streamSources, 0)
+}
+
+// TestEpgService_DeleteReturnsBeforeSweepingPrograms covers the reason this path
+// changed: deleting a source with millions of programs used to remove them inline
+// and the request timed out before the source was gone, leaving the user unable
+// to tell whether the delete had worked.
+func TestEpgService_DeleteReturnsBeforeSweepingPrograms(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	source := &models.EpgSource{
+		Name:    "Large EPG",
+		Type:    models.EpgSourceTypeXMLTV,
+		URL:     "http://example.com/epg.xml",
+		Enabled: new(true),
+	}
+	require.NoError(t, service.Create(context.Background(), source))
+
+	for range 500 {
+		require.NoError(t, programRepo.Create(context.Background(), &models.EpgProgram{
+			SourceID:  source.ID,
+			ChannelID: "ch1",
+			Title:     "Programme",
+			Start:     time.Now(),
+			Stop:      time.Now().Add(time.Hour),
+		}))
+	}
+
+	require.NoError(t, service.Delete(context.Background(), source.ID))
+
+	// The source must be gone the moment Delete returns: that is what the UI
+	// reflects, and what makes the request fast.
+	_, err := service.GetByID(context.Background(), source.ID)
+	require.Error(t, err)
+
+	// Programs are swept behind the response.
+	require.Eventually(t, func() bool {
+		return programRepo.countPrograms() == 0
+	}, 5*time.Second, 10*time.Millisecond, "background sweep did not remove the programs")
+}
+
+// TestEpgService_DeleteSurvivesRequestCancellation guards the detached context:
+// the request context is cancelled as soon as the response is written, and a
+// sweep bound to it would abort immediately, orphaning every remaining row.
+func TestEpgService_DeleteSurvivesRequestCancellation(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	source := &models.EpgSource{
+		Name:    "Cancelled EPG",
+		Type:    models.EpgSourceTypeXMLTV,
+		URL:     "http://example.com/epg.xml",
+		Enabled: new(true),
+	}
+	require.NoError(t, service.Create(context.Background(), source))
+	require.NoError(t, programRepo.Create(context.Background(), &models.EpgProgram{
+		SourceID:  source.ID,
+		ChannelID: "ch1",
+		Title:     "Programme",
+		Start:     time.Now(),
+		Stop:      time.Now().Add(time.Hour),
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, service.Delete(ctx, source.ID))
+	cancel() // as the HTTP layer does once the response is written
+
+	require.Eventually(t, func() bool {
+		return programRepo.countPrograms() == 0
+	}, 5*time.Second, 10*time.Millisecond, "sweep aborted when the request context was cancelled")
+}
+
+// TestEpgService_SweepOrphanedPrograms covers the recovery path for a sweep that
+// did not finish, since the source row is removed first and a restart in between
+// would otherwise strand its programs permanently.
+func TestEpgService_SweepOrphanedPrograms(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	live := models.NewULID()
+	orphaned := models.NewULID()
+	programRepo.knownSources[live] = true
+
+	for _, sourceID := range []models.ULID{live, live, orphaned, orphaned, orphaned} {
+		require.NoError(t, programRepo.Create(context.Background(), &models.EpgProgram{
+			SourceID:  sourceID,
+			ChannelID: "ch1",
+			Title:     "Programme",
+			Start:     time.Now(),
+			Stop:      time.Now().Add(time.Hour),
+		}))
+	}
+
+	require.NoError(t, service.SweepOrphanedPrograms(context.Background()))
+
+	if got := programRepo.countPrograms(); got != 2 {
+		t.Errorf("after sweep %d programs remain, want the 2 belonging to the live source", got)
+	}
 }


### PR DESCRIPTION
## Problem

When an origin refused a stream, the session logged it and tore itself down. The client got nothing — no picture, no reason, no hint whether to retry or check the provider.

Observed in production, every attempt dying in ~200ms:

```
11:47:57 Starting relay pipeline  channel="UK ★ Sky Sports F1 FHD"
11:47:57 Ingest loop: upstream returned non-200 status  status=555
11:48:45 ... status=999
```

## Why it was never finished

The repo already had ~1,250 lines of scaffolding for this, none of it reachable:

| component | status on `main` |
|---|---|
| `fallback.go` (557 ln) | `Manager.InitializeFallback` **never called** → `IsReady()` always false → no session ever got a controller → the whole path in `session.go` was dead |
| `buffer_injector.go` (381 ln) | `InjectStartupPlaceholder` — **no callers** |
| `placeholder_segment.go` (314 ln) | **no callers** |
| `PlaceholderType` consts | declared, **never referenced** |

The likely blocker is the ffmpeg build: the image ships a custom ffmpeg **compiled without libfreetype**, so the `drawtext` filter `fallback.go` is built on doesn't exist in it, and the image carries **no fonts at all**.

```
$ ffmpeg -f lavfi -i "color=...,drawtext=text=hello:..." -f null -
[AVFilterGraph] No such filter: 'drawtext'
```

## Approach

Text is rasterised in Go with a bitmap face from `x/image` and piped to ffmpeg as raw RGBA frames. No fonts, no fontconfig, no `drawtext`, no image rebuild — and it renders identically wherever it's deployed. Slates are encoded to the client's **negotiated codec variant**, demuxed back to ES samples through the injector's existing fMP4 path, and cached per `(variant, message)`.

**Errors are classified, not printed.** 555 and 999 — both in live use by Xtream panels, neither defined by HTTP or by the Xtream API — are reported as a connection limit rather than a generic 5xx, because the account is typically fine: the same credentials keep working against `player_api.php` while the streaming endpoint refuses. DNS failures name the host that wouldn't resolve.

**Timestamps continue from the session's current PTS** rather than restarting at zero, and live SPS/PPS is never overwritten by the slate's init data. A decoder that sees PTS jump backwards, or its configuration change underneath it, drops the stream — the exact dead stream this prevents.

**Encoder capability is probed from the ffmpeg binary**, not assumed from the codec registry: the registry knows `libaom-av1` exists but can't know whether this build has it. AV1 is excluded outright — ffmpeg encodes it happily and mediacommon then fails to demux it, the same limitation `buffer_injector.go` already documents.

On recovery the live pipeline resumes, so the channel comes back without the viewer touching anything.

## Also fixed

`NewFallbackController` was called with the untyped constant `30` as a `time.Duration` — **30 nanoseconds**. The constructor's `< 5*time.Second` clamp silently rewrote it to 30s, so it never surfaced, but the call site didn't mean what it read as.

## Testing

`go build ./...`, `go vet`, `gofmt`, `go test -race ./internal/relay/` and the full `./internal/...` suite all pass. 15 new tests cover the classification table (including 555/999), DNS/timeout/refused/passthrough classification, text wrapping, stride-padded frame packing, render output, the AV1 rejection, PTS monotonicity from a non-zero start, init-data preservation, and an end-to-end encode→demux→cache run gated on ffmpeg being present.

⚠️ **Not yet verified against a real client.** The PTS-continuity behaviour on a live decoder is the part most likely to need iteration — worth a manual check on a real player before merge.