### PR TITLE
fix(epg): delete a source's programs before its row

### DIFF
--- a/cmd/tvarr/cmd/serve.go
+++ b/cmd/tvarr/cmd/serve.go
@@ -372,13 +372,12 @@ func runServe(_ *cobra.Command, _ []string) error {
 	).WithLogger(logger).WithProgressService(progressService).
 		WithStreamSourceRepo(streamSourceRepo)
 
-	// Reclaim programs left behind by a source deletion that did not finish.
-	// Deleting a source removes its row first and sweeps the programs behind the
-	// response, so a restart mid-sweep would otherwise strand them: the source is
-	// gone, nothing queries them, and nothing else would ever remove them.
+	// Finish any source deletion whose program sweep was interrupted. Such a
+	// source is already invisible in the UI but still holds its programs, and
+	// nothing else would ever come back to it.
 	go func() {
-		if err := epgService.SweepOrphanedPrograms(context.Background()); err != nil {
-			logger.Warn("failed to sweep orphaned EPG programs on startup", slog.Any("error", err))
+		if err := epgService.FinishPendingDeletions(context.Background()); err != nil {
+			logger.Warn("failed to finish pending EPG source deletions on startup", slog.Any("error", err))
 		}
 	}()
 

--- a/internal/http/handlers/job_test.go
+++ b/internal/http/handlers/job_test.go
@@ -310,6 +310,14 @@ func (m *mockEpgSourceRepoForJob) Update(ctx context.Context, source *models.Epg
 	return nil
 }
 
+func (m *mockEpgSourceRepoForJob) SoftDelete(ctx context.Context, id models.ULID) error {
+	return nil
+}
+
+func (m *mockEpgSourceRepoForJob) ListSoftDeleted(ctx context.Context) ([]models.ULID, error) {
+	return nil, nil
+}
+
 func (m *mockEpgSourceRepoForJob) Delete(ctx context.Context, id models.ULID) error {
 	return nil
 }

--- a/internal/repository/epg_program_repo.go
+++ b/internal/repository/epg_program_repo.go
@@ -231,42 +231,6 @@ func (r *epgProgramRepo) DeleteBySourceID(ctx context.Context, sourceID models.U
 	}
 }
 
-// DeleteOrphaned removes programs whose source no longer exists, returning how
-// many rows were deleted.
-//
-// Source deletion removes the source row first so the UI responds immediately,
-// then sweeps the programs in the background. If the process stops mid-sweep the
-// remaining programs have no source, are unreachable through any query, and
-// would otherwise sit in the database forever. This reclaims them.
-func (r *epgProgramRepo) DeleteOrphaned(ctx context.Context) (int64, error) {
-	var total int64
-
-	for {
-		if err := ctx.Err(); err != nil {
-			return total, err
-		}
-
-		liveSources := r.db.Model(&models.EpgSource{}).Select("id")
-
-		ids := r.db.Model(&models.EpgProgram{}).
-			Select("id").
-			Where("source_id NOT IN (?)", liveSources).
-			Limit(epgProgramDeleteBatch)
-
-		result := r.db.WithContext(ctx).Unscoped().
-			Where("id IN (?)", ids).
-			Delete(&models.EpgProgram{})
-		if result.Error != nil {
-			return total, fmt.Errorf("deleting orphaned EPG programs after %d rows: %w", total, result.Error)
-		}
-
-		total += result.RowsAffected
-		if result.RowsAffected == 0 {
-			return total, nil
-		}
-	}
-}
-
 // DeleteStaleBySourceID deletes programs for a source that haven't been updated since the given time.
 // This implements "mark and sweep" cleanup: upsert updates the updated_at timestamp, so programs
 // not present in the new ingestion data will have an older updated_at and will be deleted.

--- a/internal/repository/epg_program_repo_test.go
+++ b/internal/repository/epg_program_repo_test.go
@@ -16,13 +16,20 @@ import (
 func setupEpgProgramTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+	// foreign_keys(ON) matches production (see internal/database/database.go).
+	// Without it SQLite silently ignores the epg_programs -> epg_sources
+	// constraint, and a delete ordering that fails in production passes here.
+	db, err := gorm.Open(sqlite.Open(":memory:?_pragma=foreign_keys(ON)"), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
 
 	err = db.AutoMigrate(&models.EpgSource{}, &models.EpgProgram{})
 	require.NoError(t, err)
+
+	var fk int
+	require.NoError(t, db.Raw("PRAGMA foreign_keys").Scan(&fk).Error)
+	require.Equal(t, 1, fk, "foreign keys must be enforced or these tests do not reflect production")
 
 	return db
 }
@@ -578,44 +585,79 @@ func TestEpgProgramRepo_DeleteBySourceID_Cancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-// TestEpgProgramRepo_DeleteOrphaned covers recovery from an interrupted sweep:
-// source deletion removes the source row first, so a restart in between leaves
-// programs that nothing queries and nothing else would ever remove.
-func TestEpgProgramRepo_DeleteOrphaned(t *testing.T) {
+// TestEpgProgramRepo_SourceDeleteOrdering pins the ordering the foreign key
+// forces. Deleting the source row while its programs remain fails outright --
+// which is exactly what shipped, because the test database did not enforce
+// foreign keys and production does.
+func TestEpgProgramRepo_SourceDeleteOrdering(t *testing.T) {
 	db := setupEpgProgramTestDB(t)
 	repo := NewEpgProgramRepository(db)
 	ctx := context.Background()
 
-	live := createTestEpgSource(t, db, "live-epg")
-	doomed := createTestEpgSource(t, db, "doomed-epg")
+	source := createTestEpgSource(t, db, "ordering-epg")
 
 	now := time.Now().Truncate(time.Second)
-	var programs []*models.EpgProgram
-	for i := range 5 {
-		programs = append(programs,
-			&models.EpgProgram{
-				SourceID: live.ID, ChannelID: "live.1",
-				Start: now.Add(time.Duration(i) * time.Minute),
-				Stop:  now.Add(time.Duration(i+1) * time.Minute),
-				Title: "Live",
-			},
-			&models.EpgProgram{
-				SourceID: doomed.ID, ChannelID: "doomed.1",
-				Start: now.Add(time.Duration(i) * time.Minute),
-				Stop:  now.Add(time.Duration(i+1) * time.Minute),
-				Title: "Orphan",
-			})
+	require.NoError(t, repo.CreateBatch(ctx, []*models.EpgProgram{{
+		SourceID:  source.ID,
+		ChannelID: "ch.1",
+		Start:     now,
+		Stop:      now.Add(time.Hour),
+		Title:     "Programme",
+	}}))
+
+	// Parent first: rejected by the constraint.
+	err := db.Unscoped().Delete(&models.EpgSource{}, "id = ?", source.ID).Error
+	require.Error(t, err, "deleting a source with programs must violate the foreign key")
+	require.Contains(t, err.Error(), "FOREIGN KEY")
+
+	// Children first, then the parent: accepted.
+	require.NoError(t, repo.DeleteBySourceID(ctx, source.ID))
+	require.NoError(t, db.Unscoped().Delete(&models.EpgSource{}, "id = ?", source.ID).Error)
+}
+
+// TestEpgSourceRepo_SoftDeleteHidesButKeepsRow covers the mechanism the delete
+// relies on: the source must vanish from ordinary queries immediately while its
+// row survives to satisfy the foreign key until the programs are gone.
+func TestEpgSourceRepo_SoftDeleteHidesButKeepsRow(t *testing.T) {
+	db := setupEpgProgramTestDB(t)
+	programRepo := NewEpgProgramRepository(db)
+	sourceRepo := NewEpgSourceRepository(db)
+	ctx := context.Background()
+
+	source := createTestEpgSource(t, db, "soft-epg")
+
+	now := time.Now().Truncate(time.Second)
+	require.NoError(t, programRepo.CreateBatch(ctx, []*models.EpgProgram{{
+		SourceID:  source.ID,
+		ChannelID: "ch.1",
+		Start:     now,
+		Stop:      now.Add(time.Hour),
+		Title:     "Programme",
+	}}))
+
+	require.NoError(t, sourceRepo.SoftDelete(ctx, source.ID))
+
+	// Invisible to the UI... (GetByID reports a missing row as nil, not an error)
+	got, err := sourceRepo.GetByID(ctx, source.ID)
+	require.NoError(t, err)
+	require.Nil(t, got, "a soft-deleted source is still visible")
+
+	all, err := sourceRepo.GetAll(ctx)
+	require.NoError(t, err)
+	for _, listed := range all {
+		require.NotEqual(t, source.ID, listed.ID, "soft-deleted source still listed")
 	}
-	require.NoError(t, repo.CreateBatch(ctx, programs))
 
-	// Simulate the source row going first, then the process stopping.
-	require.NoError(t, db.Unscoped().Delete(&models.EpgSource{}, "id = ?", doomed.ID).Error)
-
-	deleted, err := repo.DeleteOrphaned(ctx)
+	// ...but still present, so the programs' foreign key holds.
+	pending, err := sourceRepo.ListSoftDeleted(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, int64(5), deleted)
+	require.Contains(t, pending, source.ID, "unfinished deletion not reported for recovery")
 
-	remaining, err := repo.CountBySourceID(ctx, live.ID)
+	// And the deletion can be completed in the correct order.
+	require.NoError(t, programRepo.DeleteBySourceID(ctx, source.ID))
+	require.NoError(t, sourceRepo.Delete(ctx, source.ID))
+
+	pending, err = sourceRepo.ListSoftDeleted(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, int64(5), remaining, "the live source's programs were swept as orphans")
+	require.NotContains(t, pending, source.ID)
 }

--- a/internal/repository/epg_source_repo.go
+++ b/internal/repository/epg_source_repo.go
@@ -74,6 +74,38 @@ func (r *epgSourceRepo) Delete(ctx context.Context, id models.ULID) error {
 	return nil
 }
 
+// SoftDelete marks an EPG source deleted without removing the row.
+//
+// epg_programs.source_id has a foreign key onto epg_sources.id, so the source
+// row cannot be removed while any of its programs remain -- and on a large
+// source removing those first takes far longer than a request can wait. Marking
+// it deleted hides it from every ordinary query immediately (GORM scopes them to
+// deleted_at IS NULL), leaving the row in place purely to satisfy the constraint
+// until the programs have been swept.
+func (r *epgSourceRepo) SoftDelete(ctx context.Context, id models.ULID) error {
+	result := r.db.WithContext(ctx).Where("id = ?", id).Delete(&models.EpgSource{})
+	if result.Error != nil {
+		return fmt.Errorf("soft-deleting EPG source: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// ListSoftDeleted returns the IDs of sources marked deleted whose rows are still
+// present, i.e. deletions that have not finished sweeping their programs.
+func (r *epgSourceRepo) ListSoftDeleted(ctx context.Context) ([]models.ULID, error) {
+	var ids []models.ULID
+	if err := r.db.WithContext(ctx).Unscoped().
+		Model(&models.EpgSource{}).
+		Where("deleted_at IS NOT NULL").
+		Pluck("id", &ids).Error; err != nil {
+		return nil, fmt.Errorf("listing soft-deleted EPG sources: %w", err)
+	}
+	return ids, nil
+}
+
 // GetByName retrieves an EPG source by name.
 func (r *epgSourceRepo) GetByName(ctx context.Context, name string) (*models.EpgSource, error) {
 	var source models.EpgSource

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -117,6 +117,10 @@ type EpgSourceRepository interface {
 	Update(ctx context.Context, source *models.EpgSource) error
 	// Delete deletes an EPG source by ID.
 	Delete(ctx context.Context, id models.ULID) error
+	// SoftDelete marks an EPG source deleted, leaving the row for the FK.
+	SoftDelete(ctx context.Context, id models.ULID) error
+	// ListSoftDeleted returns IDs of sources whose deletion has not finished.
+	ListSoftDeleted(ctx context.Context) ([]models.ULID, error)
 	// GetByName retrieves an EPG source by name.
 	GetByName(ctx context.Context, name string) (*models.EpgSource, error)
 	// GetByURL retrieves an EPG source by URL.
@@ -145,8 +149,6 @@ type EpgProgramRepository interface {
 	Delete(ctx context.Context, id models.ULID) error
 	// DeleteBySourceID deletes all programs for a source (used when deleting the source itself).
 	DeleteBySourceID(ctx context.Context, sourceID models.ULID) error
-	// DeleteOrphaned removes programs whose source no longer exists, returning the row count.
-	DeleteOrphaned(ctx context.Context) (int64, error)
 	// DeleteStaleBySourceID deletes programs not updated since the given time (used during ingestion cleanup).
 	DeleteStaleBySourceID(ctx context.Context, sourceID models.ULID, olderThan time.Time) (int64, error)
 	// DeleteExpired deletes programs that ended before the given time.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -295,6 +295,14 @@ func (m *mockEpgSourceRepo) Update(ctx context.Context, source *models.EpgSource
 	return nil
 }
 
+func (m *mockEpgSourceRepo) SoftDelete(ctx context.Context, id models.ULID) error {
+	return nil
+}
+
+func (m *mockEpgSourceRepo) ListSoftDeleted(ctx context.Context) ([]models.ULID, error) {
+	return nil, nil
+}
+
 func (m *mockEpgSourceRepo) Delete(ctx context.Context, id models.ULID) error {
 	return nil
 }

--- a/internal/service/epg_service.go
+++ b/internal/service/epg_service.go
@@ -171,25 +171,27 @@ func (s *EpgService) Update(ctx context.Context, source *models.EpgSource) error
 	return nil
 }
 
-// Delete deletes an EPG source and all its programs.
 // Delete removes an EPG source and all of its programs.
 //
-// The source row goes first and the programs are swept in the background,
-// because a mature source holds millions of program rows and removing them takes
-// far longer than any HTTP client will wait -- deleting them inline returned a
-// request timeout to the user while the delete was still running, leaving them
-// no way to tell whether it had worked.
+// A mature source holds millions of program rows and removing them takes far
+// longer than any HTTP client will wait -- doing it inline returned a request
+// timeout while the delete was still running, leaving the user unable to tell
+// whether it had worked.
 //
-// Removing the source first is deliberate: it is a single row, so it is instant,
-// and once it is gone the source is absent from the UI and cannot be ingested
-// again. The programs left behind are unreachable through any query, and
-// SweepOrphanedPrograms reclaims them if this process stops mid-sweep.
+// The source row cannot simply go first, either: epg_programs.source_id has a
+// foreign key onto epg_sources.id, so dropping the parent while its programs
+// remain fails outright with "FOREIGN KEY constraint failed".
+//
+// So the source is marked deleted, which hides it from every ordinary query at
+// once (GORM scopes them to deleted_at IS NULL) and lets the request return
+// immediately, and the row lingers purely to satisfy the constraint while the
+// programs are swept behind the response. The row itself goes last.
 func (s *EpgService) Delete(ctx context.Context, id models.ULID) error {
-	if err := s.epgSourceRepo.Delete(ctx, id); err != nil {
+	if err := s.epgSourceRepo.SoftDelete(ctx, id); err != nil {
 		return fmt.Errorf("deleting EPG source: %w", err)
 	}
 
-	s.logger.Info("deleted EPG source, sweeping its programs in the background",
+	s.logger.Info("marked EPG source deleted, sweeping its programs in the background",
 		"id", id.String())
 
 	go func() {
@@ -198,39 +200,58 @@ func (s *EpgService) Delete(ctx context.Context, id models.ULID) error {
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), epgProgramSweepTimeout)
 		defer cancel()
 
-		started := time.Now()
-		if err := s.epgProgramRepo.DeleteBySourceID(ctx, id); err != nil {
-			// Not fatal: the rows are orphaned, and the next startup sweep
-			// reclaims them.
-			s.logger.Error("sweeping programs for deleted EPG source failed; orphans will be reclaimed on next startup",
-				"id", id.String(),
-				"elapsed", time.Since(started),
-				"error", err)
-			return
+		if err := s.finishDeletion(ctx, id); err != nil {
+			// Not fatal: the source is already invisible, and the next startup
+			// finishes what is left.
+			s.logger.Error("sweeping programs for deleted EPG source failed; will retry on next startup",
+				"id", id.String(), "error", err)
 		}
-
-		s.logger.Info("swept programs for deleted EPG source",
-			"id", id.String(),
-			"elapsed", time.Since(started))
 	}()
 
 	return nil
 }
 
-// SweepOrphanedPrograms removes programs left behind by a source deletion that
-// did not finish. Intended to be called once at startup.
-func (s *EpgService) SweepOrphanedPrograms(ctx context.Context) error {
+// finishDeletion removes a soft-deleted source's programs and then its row.
+func (s *EpgService) finishDeletion(ctx context.Context, id models.ULID) error {
 	started := time.Now()
 
-	deleted, err := s.epgProgramRepo.DeleteOrphaned(ctx)
-	if err != nil {
-		return fmt.Errorf("sweeping orphaned EPG programs: %w", err)
+	if err := s.epgProgramRepo.DeleteBySourceID(ctx, id); err != nil {
+		return fmt.Errorf("deleting programs: %w", err)
 	}
 
-	if deleted > 0 {
-		s.logger.Info("reclaimed orphaned EPG programs",
-			"count", deleted,
-			"elapsed", time.Since(started))
+	// Only now is the foreign key satisfied and the row free to go.
+	if err := s.epgSourceRepo.Delete(ctx, id); err != nil {
+		return fmt.Errorf("deleting EPG source row: %w", err)
+	}
+
+	s.logger.Info("finished deleting EPG source",
+		"id", id.String(), "elapsed", time.Since(started))
+
+	return nil
+}
+
+// FinishPendingDeletions completes source deletions whose program sweep did not
+// finish. Intended to be called once at startup.
+//
+// A source marked deleted whose row is still present is an interrupted sweep:
+// invisible in the UI, still holding its programs, with nothing else that would
+// ever come back to it.
+func (s *EpgService) FinishPendingDeletions(ctx context.Context) error {
+	ids, err := s.epgSourceRepo.ListSoftDeleted(ctx)
+	if err != nil {
+		return fmt.Errorf("listing unfinished EPG source deletions: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	s.logger.Info("resuming unfinished EPG source deletions", "count", len(ids))
+
+	for _, id := range ids {
+		if err := s.finishDeletion(ctx, id); err != nil {
+			s.logger.Error("could not finish EPG source deletion",
+				"id", id.String(), "error", err)
+		}
 	}
 
 	return nil

--- a/internal/service/epg_service_test.go
+++ b/internal/service/epg_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"gorm.io/gorm"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +16,11 @@ import (
 
 // Mock EPG Source Repository
 type mockEpgSourceRepo struct {
+	// mu guards the maps: deletion now sweeps on a background goroutine.
+	mu sync.Mutex
+	// softDeleted mirrors the real schema, where a deleted source keeps its row
+	// (so the programs' foreign key still resolves) but disappears from reads.
+	softDeleted map[models.ULID]bool
 	sources     map[models.ULID]*models.EpgSource
 	createErr   error
 	getErr      error
@@ -41,14 +47,47 @@ func (m *mockEpgSourceRepo) Create(ctx context.Context, source *models.EpgSource
 }
 
 func (m *mockEpgSourceRepo) GetByID(ctx context.Context, id models.ULID) (*models.EpgSource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
 	source, ok := m.sources[id]
-	if !ok {
+	if !ok || m.softDeleted[id] {
 		return nil, errors.New("not found")
 	}
 	return source, nil
+}
+
+func (m *mockEpgSourceRepo) SoftDelete(ctx context.Context, id models.ULID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	if _, ok := m.sources[id]; !ok {
+		return gorm.ErrRecordNotFound
+	}
+	if m.softDeleted == nil {
+		m.softDeleted = make(map[models.ULID]bool)
+	}
+	m.softDeleted[id] = true
+	return nil
+}
+
+func (m *mockEpgSourceRepo) ListSoftDeleted(ctx context.Context) ([]models.ULID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var ids []models.ULID
+	for id := range m.softDeleted {
+		if _, ok := m.sources[id]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
 }
 
 func (m *mockEpgSourceRepo) GetAll(ctx context.Context) ([]*models.EpgSource, error) {
@@ -84,10 +123,14 @@ func (m *mockEpgSourceRepo) Update(ctx context.Context, source *models.EpgSource
 }
 
 func (m *mockEpgSourceRepo) Delete(ctx context.Context, id models.ULID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
 	delete(m.sources, id)
+	delete(m.softDeleted, id)
 	return nil
 }
 
@@ -777,32 +820,80 @@ func TestEpgService_DeleteSurvivesRequestCancellation(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "sweep aborted when the request context was cancelled")
 }
 
-// TestEpgService_SweepOrphanedPrograms covers the recovery path for a sweep that
-// did not finish, since the source row is removed first and a restart in between
-// would otherwise strand its programs permanently.
-func TestEpgService_SweepOrphanedPrograms(t *testing.T) {
+// TestEpgService_FinishPendingDeletions covers recovery from a sweep that did
+// not finish: the source is marked deleted and invisible, but its row and
+// programs remain, and nothing else would come back to them.
+func TestEpgService_FinishPendingDeletions(t *testing.T) {
 	sourceRepo := newMockEpgSourceRepo()
 	programRepo := newMockEpgProgramRepo()
 	service := NewEpgService(sourceRepo, programRepo,
 		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
 
-	live := models.NewULID()
-	orphaned := models.NewULID()
-	programRepo.knownSources[live] = true
-
-	for _, sourceID := range []models.ULID{live, live, orphaned, orphaned, orphaned} {
-		require.NoError(t, programRepo.Create(context.Background(), &models.EpgProgram{
-			SourceID:  sourceID,
-			ChannelID: "ch1",
-			Title:     "Programme",
-			Start:     time.Now(),
-			Stop:      time.Now().Add(time.Hour),
-		}))
+	source := &models.EpgSource{
+		Name:    "Interrupted EPG",
+		Type:    models.EpgSourceTypeXMLTV,
+		URL:     "http://example.com/epg.xml",
+		Enabled: new(true),
 	}
+	require.NoError(t, service.Create(context.Background(), source))
+	require.NoError(t, programRepo.Create(context.Background(), &models.EpgProgram{
+		SourceID:  source.ID,
+		ChannelID: "ch1",
+		Title:     "Programme",
+		Start:     time.Now(),
+		Stop:      time.Now().Add(time.Hour),
+	}))
 
-	require.NoError(t, service.SweepOrphanedPrograms(context.Background()))
+	// Simulate the interruption: marked deleted, nothing swept.
+	require.NoError(t, sourceRepo.SoftDelete(context.Background(), source.ID))
 
-	if got := programRepo.countPrograms(); got != 2 {
-		t.Errorf("after sweep %d programs remain, want the 2 belonging to the live source", got)
+	pending, err := sourceRepo.ListSoftDeleted(context.Background())
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "the unfinished deletion was not detected")
+
+	require.NoError(t, service.FinishPendingDeletions(context.Background()))
+
+	assert.Zero(t, programRepo.countPrograms(), "programs survived the recovery sweep")
+
+	pending, err = sourceRepo.ListSoftDeleted(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, pending, "the source row was not removed after its programs")
+}
+
+// TestEpgService_DeleteRemovesProgramsBeforeTheSourceRow pins the ordering the
+// foreign key forces. Removing the source row first fails outright in
+// production, which is exactly what shipped when this was reordered for speed.
+func TestEpgService_DeleteRemovesProgramsBeforeTheSourceRow(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	source := &models.EpgSource{
+		Name:    "Ordered EPG",
+		Type:    models.EpgSourceTypeXMLTV,
+		URL:     "http://example.com/epg.xml",
+		Enabled: new(true),
 	}
+	require.NoError(t, service.Create(context.Background(), source))
+	require.NoError(t, programRepo.Create(context.Background(), &models.EpgProgram{
+		SourceID:  source.ID,
+		ChannelID: "ch1",
+		Title:     "Programme",
+		Start:     time.Now(),
+		Stop:      time.Now().Add(time.Hour),
+	}))
+
+	require.NoError(t, service.Delete(context.Background(), source.ID))
+
+	// Hidden immediately, so the UI responds without waiting for the sweep.
+	got, err := service.GetByID(context.Background(), source.ID)
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	// The row survives only until its programs are gone, then goes itself.
+	require.Eventually(t, func() bool {
+		pending, err := sourceRepo.ListSoftDeleted(context.Background())
+		return err == nil && len(pending) == 0 && programRepo.countPrograms() == 0
+	}, 5*time.Second, 10*time.Millisecond, "deletion did not complete in the background")
 }

--- a/internal/service/job_service_test.go
+++ b/internal/service/job_service_test.go
@@ -351,6 +351,14 @@ func (m *jobMockEpgSourceRepo) Update(ctx context.Context, source *models.EpgSou
 	return nil
 }
 
+func (m *jobMockEpgSourceRepo) SoftDelete(ctx context.Context, id models.ULID) error {
+	return nil
+}
+
+func (m *jobMockEpgSourceRepo) ListSoftDeleted(ctx context.Context) ([]models.ULID, error) {
+	return nil, nil
+}
+
 func (m *jobMockEpgSourceRepo) Delete(ctx context.Context, id models.ULID) error {
 	return nil
 }


### PR DESCRIPTION
## The bug I shipped

PR #15 reordered EPG source deletion to remove the source row first so the request could return immediately, sweeping its millions of programs behind the response. That ordering is invalid: `epg_programs.source_id` has a foreign key onto `epg_sources.id`, so dropping the parent while its children remain fails outright.

```
DELETE FROM `epg_sources` WHERE id = "01KCEFFB0J3VQJNT1C174CHN7W"
constraint failed: FOREIGN KEY constraint failed (787)
```

The original timeout **is** fixed — the request now returns in 112ms instead of hanging — but it returns a 500.

## Why the tests missed it

The repository suite opened `gorm.Open(sqlite.Open(":memory:"))`, which leaves SQLite's `foreign_keys` pragma **off**. Production sets `_pragma=foreign_keys(ON)` (`internal/database/database.go`). So the test database silently permitted a delete ordering the real one rejects, and the service tests use mocks with no constraint at all.

The suite now opens with the pragma set **and asserts it is on**, so a test database that doesn't reflect production fails loudly instead of green-lighting impossible SQL.

## The fix

Mark the source deleted rather than removing it. GORM scopes ordinary reads to `deleted_at IS NULL`, so it disappears from the UI immediately and the request still returns at once, while the row stays purely to satisfy the constraint until the programs are swept. The row goes **last**, once the foreign key permits it.

Recovery changes shape with it: orphaned programs can't exist under the constraint, so `DeleteOrphaned` is gone. What an interrupted sweep actually leaves is a source marked deleted whose row is still present — invisible in the UI, still holding its programs. `FinishPendingDeletions` resumes those, and `serve.go` runs it at startup as before.

## Coverage added

- The ordering itself — parent-first is rejected with `FOREIGN KEY`, children-then-parent succeeds.
- Soft deletion hides a source from `GetByID`/`GetAll` while keeping its row and reporting it via `ListSoftDeleted`.
- Resuming an interrupted deletion removes both the programs and the row.
- The existing async guarantees still hold: `Delete` returns with the source already hidden, the sweep survives request-context cancellation, and it completes in the background.

`go build`, `go vet`, `gofmt`, the full `./internal/... ./cmd/...` suite and `golangci-lint` (0 issues) all pass.