### PR TITLE
fix(relay): let clients in once the error slate is buffered

### DIFF
--- a/internal/relay/error_slate_test.go
+++ b/internal/relay/error_slate_test.go
@@ -368,3 +368,72 @@ func TestSlateEndToEnd(t *testing.T) {
 		t.Errorf("cached lookup took %v, cache is not working", elapsed)
 	}
 }
+
+// TestPublishForClientsReleasesWaiters is the regression test for a slate that
+// was rendered, buffered, and then never delivered.
+//
+// The session only signalled readiness on the successful pipeline path, so a
+// client blocked in WaitReady until its own timeout: mpv waited 60 seconds and
+// received a 503, while the "Too Many Connections" picture it should have shown
+// sat complete in the buffer.
+func TestPublishForClientsReleasesWaiters(t *testing.T) {
+	s := &RelaySession{readyCh: make(chan struct{})}
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	defer s.cancel()
+
+	if s.IsReady() {
+		t.Fatal("a fresh session must not report ready")
+	}
+
+	// A client arriving before the pipeline publishes must block.
+	blocked := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		blocked <- s.WaitReady(ctx)
+	}()
+
+	select {
+	case err := <-blocked:
+		t.Fatalf("WaitReady returned %v before the pipeline was published", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	s.publishForClients(NewCodecVariant("h264", "aac"), 4, 10, 5)
+
+	select {
+	case err := <-blocked:
+		if err != nil {
+			t.Fatalf("WaitReady returned %v after publishing", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client stayed blocked after the pipeline was published")
+	}
+
+	if !s.IsReady() {
+		t.Error("session does not report ready after publishing")
+	}
+	// The output path needs both of these, or it fails right after WaitReady.
+	if s.processorConfig == nil {
+		t.Error("processorConfig not set; on-demand processor creation will fail")
+	}
+	if s.formatRouter == nil {
+		t.Error("formatRouter not set; the client's format cannot be routed")
+	}
+}
+
+// TestPublishForClientsIsIdempotent covers recovery: the slate publishes, then
+// the origin returns and the normal pipeline publishes again on the same
+// session. markReady closes a channel, so a second call must not panic.
+func TestPublishForClientsIsIdempotent(t *testing.T) {
+	s := &RelaySession{readyCh: make(chan struct{})}
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	defer s.cancel()
+
+	s.publishForClients(NewCodecVariant("h264", "aac"), 4, 10, 5)
+	s.publishForClients(NewCodecVariant("h264", "aac"), 4, 10, 5)
+
+	if !s.IsReady() {
+		t.Error("session not ready after repeated publishing")
+	}
+}

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -471,6 +471,31 @@ const liveSPSScanSamples = 256
 // timelines never collide, small enough to be invisible.
 const slatePTSGap = 3600
 
+// publishForClients makes the session consumable: it records the config used to
+// build processors on demand, installs the format router, and signals readiness.
+//
+// Every path that produces content for clients has to do this, not just the
+// successful one. A session that skips it leaves clients blocked in WaitReady
+// until their own timeout expires -- the error slate did exactly that, and mpv
+// sat for 60s and got a 503 rather than the picture that had already been
+// rendered and buffered for it.
+func (s *RelaySession) publishForClients(targetVariant CodecVariant, targetSegmentDuration float64, maxSegments, playlistSegments int) {
+	// Processors are NOT created here - they are created on-demand when clients
+	// connect, via GetOrCreateProcessor().
+	s.processorConfig = &ProcessorConfig{
+		TargetVariant:         targetVariant,
+		TargetSegmentDuration: targetSegmentDuration,
+		MaxSegments:           maxSegments,
+		PlaylistSegments:      playlistSegments,
+	}
+
+	if s.formatRouter == nil {
+		s.formatRouter = NewFormatRouter(models.ContainerFormatMPEGTS)
+	}
+
+	s.markReady()
+}
+
 // slateVariant picks the codec variant to render the error slate in.
 //
 // When the origin failed before any codec was detected -- the common case, since
@@ -570,6 +595,16 @@ func (s *RelaySession) serveErrorSlate(cause error) (recovered bool, err error) 
 
 	s.slatePTS.Store(InjectErrorSlate(esVariant, slate, s.slatePTS.Load(), slateLead))
 	s.lastActivity.Store(time.Now())
+
+	// Content is in the buffer, so let clients in. Without this the session never
+	// becomes ready and every client blocks until it times out, which is the dead
+	// stream the slate exists to replace.
+	s.publishForClients(
+		variant,
+		s.manager.config.HLSConfig.TargetSegmentDuration,
+		s.manager.config.HLSConfig.MaxSegments,
+		s.manager.config.HLSConfig.PlaylistSegments,
+	)
 
 	for {
 		select {
@@ -1037,22 +1072,7 @@ func (s *RelaySession) runESPipeline() error {
 		slog.String("session_id", s.ID.String()),
 		slog.String("target_variant", targetVariant.String()))
 
-	// Store processor config for on-demand creation
-	// Processors are NOT created here - they are created on-demand when clients connect
-	s.processorConfig = &ProcessorConfig{
-		TargetVariant:         targetVariant,
-		TargetSegmentDuration: targetSegmentDuration,
-		MaxSegments:           maxSegments,
-		PlaylistSegments:      playlistSegments,
-	}
-
-	// Set up format router WITHOUT pre-created processors
-	// Processors will be created on-demand via GetOrCreateProcessor()
-	s.formatRouter = NewFormatRouter(models.ContainerFormatMPEGTS)
-
-	// Signal that the pipeline is ready for clients
-	// Clients will trigger on-demand processor creation when they connect
-	s.markReady()
+	s.publishForClients(targetVariant, targetSegmentDuration, maxSegments, playlistSegments)
 
 	slog.Debug("Started ES-based pipeline (processors created on-demand)",
 		slog.String("session_id", s.ID.String()),


### PR DESCRIPTION
## What happened on the cluster

The slate was rendered, buffered, and never delivered. Against the live provider it got almost everything right:

```
18:47:29  upstream returned non-200  status=999  kind=limit_reached
                                     headline="Too Many Connections"
18:47:29  rendered error slate       h264/aac 1280x720, 20 video / 95 audio samples
18:47:29  Serving error slate
```

and then mpv sat for sixty seconds and got a 503:

```
18:48:28  Session not ready for MPEG-TS streaming  error="context canceled"
18:48:28  GET /proxy/... 503  duration=60.1s
```

The 999 was classified correctly, the picture was encoded in the client's negotiated codec, and it was sitting complete in the buffer the entire time the client was waiting.

## Cause

`markReady()`, `processorConfig` and `formatRouter` were only ever set up on the successful pipeline path (`session.go:1042`, `:1051`, `:1055`). A session serving a slate did none of them:

| step | normal path | slate path |
|---|---|---|
| source variant | ✓ | ✓ |
| `processorConfig` | ✓ | ✗ |
| `formatRouter` | ✓ | ✗ |
| `markReady()` | ✓ | ✗ |

So `WaitReady` blocked until the client's own timeout. And readiness alone would not have been enough — the next call, `GetOrCreateMPEGTSProcessorForVariant`, fails immediately on a nil `processorConfig`.

## Fix

Extract the three steps as `publishForClients(...)` and call it from both paths, so that *producing content for clients* is what makes a session consumable — not *producing it successfully*.

## Tests

- A client blocked in `WaitReady` is released by publishing, and both `processorConfig` and `formatRouter` are set (readiness alone isn't sufficient).
- Publishing twice does not panic — this happens when an origin recovers and the normal pipeline publishes over a slate, and `markReady` closes a channel.

`go build`, `vet`, `gofmt`, `-race`, the full `./internal/... ./cmd/...` suite and `golangci-lint` (0 issues) all pass.

⚠️ Still needs a real client to confirm the slate actually plays. The tests prove the session becomes consumable; only mpv can prove the picture arrives.