### PR TITLE
fix(relay): slate layout, and stop client-less live sessions living forever

### DIFF
--- a/internal/relay/error_slate.go
+++ b/internal/relay/error_slate.go
@@ -106,10 +106,25 @@ func NewUpstreamStatusError(status int) *StreamError {
 	e := &StreamError{HTTPStatus: status}
 
 	switch {
-	case status == 429, status == 509, status == 555, status == 999:
+	case status == 429 || status == 509:
+		// Standard, and actually mean rate/bandwidth limiting.
 		e.Kind = StreamErrorLimitReached
 		e.Headline = "Too Many Connections"
-		e.Detail = fmt.Sprintf("Provider refused the stream (HTTP %d). Another device may be watching.", status)
+		e.Detail = fmt.Sprintf("Provider is rate-limiting this account (HTTP %d).", status)
+
+	case status == 555 || status == 666 || status > 599:
+		// Xtream panels return codes of their own -- 555, 666 and 999 have all
+		// been observed -- with empty bodies and no consistency: the
+		// same URL requested twice returns different ones. They were originally
+		// read here as a concurrency refusal, which was wrong and actively
+		// misleading: the account reported max_connections 1 with active_cons 0
+		// at the moment of refusal, so the slate sent the viewer looking for
+		// another device that was not there.
+		//
+		// Report what was observed and leave the cause alone.
+		e.Kind = StreamErrorUnavailable
+		e.Headline = "Channel Unavailable"
+		e.Detail = fmt.Sprintf("Provider refused the stream (HTTP %d).", status)
 
 	case status == 401 || status == 403:
 		e.Kind = StreamErrorUnavailable

--- a/internal/relay/error_slate.go
+++ b/internal/relay/error_slate.go
@@ -575,6 +575,86 @@ var (
 	slateDetail     = color.RGBA{R: 0x9a, G: 0xa4, B: 0xb2, A: 0xff}
 )
 
+// slateBlock is one positioned run of text in the slate layout.
+type slateBlock struct {
+	face   font.Face
+	text   string
+	scale  int
+	colour color.RGBA
+	rect   image.Rectangle
+}
+
+// faceLineHeight returns the full line height of a face, in pixels at 1x.
+func faceLineHeight(f font.Face) int {
+	m := f.Metrics()
+	return (m.Ascent + m.Descent).Round()
+}
+
+// layoutSlate positions the accent rule and the text blocks as one vertically
+// centred stack.
+//
+// Every offset comes from the measured line height of the face that will draw
+// it. Fixed multiples of the scale were used here at first and they overlapped:
+// drawScaledText takes y as the TOP of a block, so a 48px headline drawn at the
+// vertical centre ran to centre+48 while the detail line began at centre+30, and
+// the two were rendered through each other on screen.
+//
+// Returned separately from the drawing so the geometry can be asserted directly.
+func layoutSlate(se *StreamError, size SlateSize, headScale, detailScale int) (image.Rectangle, []slateBlock) {
+	headFace := inconsolata.Bold8x16
+	detailFace := basicfont.Face7x13
+
+	headH := faceLineHeight(headFace) * headScale
+	detailH := faceLineHeight(detailFace) * detailScale
+
+	// Breathing room proportional to the type, so it holds at any raster size.
+	gap := headH / 2
+	ruleH := max(headScale, 2)
+	ruleW := size.Width / 3
+
+	// Wrap the detail so a long provider message does not run off the raster.
+	margin := size.Width / 10
+	advance := max(detailFace.Advance*detailScale, 1)
+	lines := wrapText(se.Detail, max((size.Width-2*margin)/advance, 20))
+
+	total := ruleH + gap + headH
+	if len(lines) > 0 {
+		total += gap + len(lines)*detailH
+	}
+
+	y := max((size.Height-total)/2, 0)
+
+	rule := image.Rect((size.Width-ruleW)/2, y, (size.Width+ruleW)/2, y+ruleH)
+	y += ruleH + gap
+
+	blocks := make([]slateBlock, 0, 1+len(lines))
+
+	headW := textWidth(headFace, se.Headline) * headScale
+	blocks = append(blocks, slateBlock{
+		face: headFace, text: se.Headline, scale: headScale, colour: slateHeadline,
+		rect: image.Rect((size.Width-headW)/2, y, (size.Width+headW)/2, y+headH),
+	})
+	y += headH + gap
+
+	for _, line := range lines {
+		w := textWidth(detailFace, line) * detailScale
+		blocks = append(blocks, slateBlock{
+			face: detailFace, text: line, scale: detailScale, colour: slateDetail,
+			rect: image.Rect((size.Width-w)/2, y, (size.Width+w)/2, y+detailH),
+		})
+		y += detailH
+	}
+
+	return rule, blocks
+}
+
+// slateScales returns the type scales for a raster, so a 4K slate is not
+// captioned in text sized for 720p and an SD one does not overflow.
+func (g *ErrorSlateGenerator) slateScales(size SlateSize) (head, detail int) {
+	head = max(g.config.Scale*size.Height/720, 1)
+	return head, max(head-1, 1)
+}
+
 // render rasterises the slate for an error at the given size.
 func (g *ErrorSlateGenerator) render(se *StreamError, size SlateSize) *image.RGBA {
 	size = size.normalise(g.config)
@@ -582,34 +662,12 @@ func (g *ErrorSlateGenerator) render(se *StreamError, size SlateSize) *image.RGB
 	img := image.NewRGBA(image.Rect(0, 0, size.Width, size.Height))
 	draw.Draw(img, img.Bounds(), &image.Uniform{slateBackground}, image.Point{}, draw.Src)
 
-	// Scale typography with the raster so a 4K slate is not captioned in text
-	// sized for 720p, and an SD one does not overflow.
-	headScale := max(g.config.Scale*size.Height/720, 1)
-	detailScale := max(headScale-1, 1)
+	headScale, detailScale := g.slateScales(size)
+	rule, blocks := layoutSlate(se, size, headScale, detailScale)
 
-	// A thin accent rule above the headline gives the slate an obvious top edge
-	// on displays that overscan.
-	ruleW := size.Width / 3
-	ruleH := max(headScale, 2)
-	ruleY := size.Height/2 - 12*headScale - 6*ruleH
-	drawRect(img, (size.Width-ruleW)/2, ruleY, ruleW, ruleH, slateAccent)
-
-	headFace := inconsolata.Bold8x16
-	headText := se.Headline
-	headW := textWidth(headFace, headText) * headScale
-	drawScaledText(img, headFace, headText,
-		(size.Width-headW)/2, size.Height/2, headScale, slateHeadline)
-
-	// Wrap the detail so a long provider message does not run off the raster.
-	detailFace := basicfont.Face7x13
-	maxChars := max((size.Width-80)/(detailFace.Advance*detailScale), 20)
-	lines := wrapText(se.Detail, maxChars)
-
-	y := size.Height/2 + 10*headScale
-	for _, line := range lines {
-		w := textWidth(detailFace, line) * detailScale
-		drawScaledText(img, detailFace, line, (size.Width-w)/2, y, detailScale, slateDetail)
-		y += 16 * detailScale
+	drawRect(img, rule.Min.X, rule.Min.Y, rule.Dx(), rule.Dy(), slateAccent)
+	for _, b := range blocks {
+		drawScaledText(img, b.face, b.text, b.rect.Min.X, b.rect.Min.Y, b.scale, b.colour)
 	}
 
 	return img

--- a/internal/relay/error_slate_test.go
+++ b/internal/relay/error_slate_test.go
@@ -520,3 +520,38 @@ func TestSlateLayoutIsVerticallyCentred(t *testing.T) {
 		}
 	}
 }
+
+// TestShouldRetainForDraining pins when running transcoders may keep a session
+// with no clients alive.
+//
+// The exemption exists so a finite stream can finish transcoding after its last
+// client leaves. It was applied to any running transcoder, and a live origin
+// never finishes, so such a session was immortal: no clients, grace period never
+// applied, cleanup skipping it forever, and its upstream connection held open.
+// The provider allows a fixed number of concurrent connections, so every
+// abandoned session permanently consumed one.
+func TestShouldRetainForDraining(t *testing.T) {
+	tests := []struct {
+		name            string
+		transcoders     int
+		ingestCompleted bool
+		want            bool
+	}{
+		{"live origin, no clients - must not be retained", 2, false, false},
+		{"finite origin still draining - retained", 2, true, true},
+		{"finite origin, nothing left to drain", 0, true, false},
+		{"live origin, no transcoders", 0, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &RelaySession{}
+			s.ingestCompleted.Store(tt.ingestCompleted)
+
+			if got := s.shouldRetainForDraining(tt.transcoders); got != tt.want {
+				t.Errorf("shouldRetainForDraining(%d) with ingestCompleted=%v = %v, want %v",
+					tt.transcoders, tt.ingestCompleted, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/relay/error_slate_test.go
+++ b/internal/relay/error_slate_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/image/font/basicfont"
 )
 
 // newTestESVariant builds a standalone h264/aac variant for injection tests.
@@ -435,5 +437,86 @@ func TestPublishForClientsIsIdempotent(t *testing.T) {
 
 	if !s.IsReady() {
 		t.Error("session not ready after repeated publishing")
+	}
+}
+
+// TestSlateLayoutNeverOverlaps is the regression test for a slate that reached a
+// real client and was unreadable: the headline and the detail line were drawn
+// through each other, because the vertical offsets were fixed multiples of the
+// scale rather than the measured height of the text being drawn.
+func TestSlateLayoutNeverOverlaps(t *testing.T) {
+	sizes := []SlateSize{
+		{Width: 640, Height: 360},
+		{Width: 1280, Height: 720},
+		{Width: 1920, Height: 1080},
+		{Width: 3840, Height: 2160},
+	}
+	errs := []*StreamError{
+		NewUpstreamStatusError(555),
+		NewUpstreamStatusError(999),
+		NewUpstreamStatusError(404),
+		ClassifyStreamError(&net.DNSError{Err: "no such host", Name: "cf.bek252.xyz"}),
+		{Kind: StreamErrorUnavailable, Headline: "Channel Unavailable", Detail: strings.Repeat("a very long provider message that has to wrap ", 6)},
+		{Kind: StreamErrorEnded, Headline: "Ended", Detail: ""},
+	}
+
+	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
+
+	for _, size := range sizes {
+		for _, se := range errs {
+			name := fmt.Sprintf("%dx%d/%s", size.Width, size.Height, se.Headline)
+			t.Run(name, func(t *testing.T) {
+				head, detail := g.slateScales(size)
+				rule, blocks := layoutSlate(se, size, head, detail)
+
+				all := append([]image.Rectangle{rule}, func() []image.Rectangle {
+					r := make([]image.Rectangle, len(blocks))
+					for i, b := range blocks {
+						r[i] = b.rect
+					}
+					return r
+				}()...)
+
+				bounds := image.Rect(0, 0, size.Width, size.Height)
+				for i, a := range all {
+					if a.Empty() {
+						t.Errorf("element %d has no area: %v", i, a)
+					}
+					if !a.In(bounds) {
+						t.Errorf("element %d escapes the raster: %v not within %v", i, a, bounds)
+					}
+					for j := i + 1; j < len(all); j++ {
+						if a.Overlaps(all[j]) {
+							t.Errorf("elements %d and %d overlap: %v ∩ %v = %v",
+								i, j, a, all[j], a.Intersect(all[j]))
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestSlateLayoutIsVerticallyCentred keeps the stack balanced rather than
+// drifting to one edge as the detail wraps onto more lines.
+func TestSlateLayoutIsVerticallyCentred(t *testing.T) {
+	g := NewErrorSlateGenerator(DefaultErrorSlateConfig(), nil)
+	size := SlateSize{Width: 1280, Height: 720}
+	head, detail := g.slateScales(size)
+
+	for _, se := range []*StreamError{
+		NewUpstreamStatusError(999),
+		{Kind: StreamErrorUnavailable, Headline: "Wrapped", Detail: strings.Repeat("word ", 40)},
+	} {
+		rule, blocks := layoutSlate(se, size, head, detail)
+
+		top := rule.Min.Y
+		bottom := blocks[len(blocks)-1].rect.Max.Y
+		above, below := top, size.Height-bottom
+
+		// Allow a line's slack; exact symmetry is not the point, balance is.
+		if diff := above - below; diff > faceLineHeight(basicfont.Face7x13)*detail || diff < -faceLineHeight(basicfont.Face7x13)*detail {
+			t.Errorf("%q: stack is off-centre - %dpx above, %dpx below", se.Headline, above, below)
+		}
 	}
 }

--- a/internal/relay/error_slate_test.go
+++ b/internal/relay/error_slate_test.go
@@ -30,8 +30,12 @@ func TestNewUpstreamStatusError(t *testing.T) {
 		// The two codes seen in production from the Xtream panel. Neither is a
 		// real HTTP status, and both mean the panel refused the stream while the
 		// same account still authenticates against player_api.php.
-		{"xtream 555", 555, StreamErrorLimitReached, "Too Many Connections"},
-		{"xtream 999", 999, StreamErrorLimitReached, "Too Many Connections"},
+		// Non-standard panel codes: observed rotating between 555, 666 and 999
+		// for the same URL, so they carry no reliable meaning and must not be
+		// reported as a concurrency limit.
+		{"xtream 555", 555, StreamErrorUnavailable, "Channel Unavailable"},
+		{"xtream 666", 666, StreamErrorUnavailable, "Channel Unavailable"},
+		{"xtream 999", 999, StreamErrorUnavailable, "Channel Unavailable"},
 		{"too many requests", 429, StreamErrorLimitReached, "Too Many Connections"},
 		{"bandwidth limit", 509, StreamErrorLimitReached, "Too Many Connections"},
 		{"unauthorized", 401, StreamErrorUnavailable, "Not Authorised"},
@@ -72,7 +76,7 @@ func TestClassifyStreamError(t *testing.T) {
 	})
 
 	t.Run("existing StreamError passes through unchanged", func(t *testing.T) {
-		orig := NewUpstreamStatusError(555)
+		orig := NewUpstreamStatusError(429)
 		got := ClassifyStreamError(fmt.Errorf("wrapped: %w", orig))
 		if got != orig {
 			t.Fatalf("classification replaced the precise error: got %+v", got)

--- a/internal/relay/manager.go
+++ b/internal/relay/manager.go
@@ -181,6 +181,7 @@ type Manager struct {
 	connectionPool           *ConnectionPool
 	fallbackGenerator        *FallbackGenerator
 	errorSlateGenerator      *ErrorSlateGenerator
+	accountProber            *AccountProber
 	daemonRegistry           *DaemonRegistry
 	daemonStreamMgr          *DaemonStreamManager
 	activeJobMgr             *ActiveJobManager
@@ -242,6 +243,7 @@ func NewManager(config ManagerConfig) *Manager {
 		connectionPool:           NewConnectionPool(config.ConnectionPoolConfig),
 		fallbackGenerator:        NewFallbackGenerator(config.FallbackConfig, logger),
 		errorSlateGenerator:      NewErrorSlateGenerator(config.ErrorSlateConfig, logger),
+		accountProber:            NewAccountProber(config.HTTPClient, logger),
 		daemonRegistry:           config.DaemonRegistry,
 		daemonStreamMgr:          config.DaemonStreamManager,
 		activeJobMgr:             config.ActiveJobManager,
@@ -907,6 +909,7 @@ func (m *Manager) createSession(ctx context.Context, channelID models.ULID, chan
 	// fallback there is nothing to pre-warm and no readiness gate: a session
 	// always gets a generator and always has something to show on failure.
 	session.errorSlateGenerator = m.errorSlateGenerator
+	session.accountProber = m.accountProber
 
 	// Initialize fallback controller if fallback generator is ready
 	// Note: Fallback settings are now managed at the manager level, not profile level

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -206,6 +206,9 @@ type RelaySession struct {
 
 	// errorSlateGenerator renders viewer-facing slates for pipeline failures.
 	errorSlateGenerator *ErrorSlateGenerator
+	// accountProber asks the provider what it thinks of the account, so a slate
+	// can report a real cause instead of an opaque refusal code.
+	accountProber *AccountProber
 	// slateErr holds the classified error currently being shown as a slate.
 	slateErr atomic.Pointer[StreamError]
 	// slatePTS is the next PTS to write slate samples at, kept monotonic across
@@ -496,6 +499,46 @@ func (s *RelaySession) publishForClients(targetVariant CodecVariant, targetSegme
 	s.markReady()
 }
 
+// explainWithAccount replaces a bare refusal with whatever the provider's own
+// account record explains, when it explains anything.
+//
+// The codes an Xtream panel returns on a refused stream mean nothing reliable:
+// the same URL answered 555, then 999, with 666 on another channel, all with
+// empty bodies. Guessing a cause from them produced a slate that told the viewer
+// to look for another device while the account reported zero connections in use.
+// player_api.php is the panel's own answer, so ask it and report that instead.
+func (s *RelaySession) explainWithAccount(streamErr *StreamError) *StreamError {
+	// Only worth asking when the provider answered at all. A DNS or dial failure
+	// has already been classified precisely, and the panel is unreachable anyway.
+	if s.accountProber == nil || streamErr == nil || streamErr.HTTPStatus == 0 {
+		return streamErr
+	}
+
+	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+	defer cancel()
+
+	account, err := s.accountProber.Account(ctx, s.StreamURL)
+	if err != nil {
+		slog.Debug("Could not read provider account state",
+			slog.String("session_id", s.ID.String()),
+			slog.String("error", err.Error()))
+		return streamErr
+	}
+
+	refined := account.Refine(streamErr)
+	if refined != streamErr {
+		slog.Info("Provider account explains the refusal",
+			slog.String("session_id", s.ID.String()),
+			slog.Int("status", streamErr.HTTPStatus),
+			slog.String("headline", refined.Headline),
+			slog.Int("active_cons", account.ActiveCons),
+			slog.Int("max_connections", account.MaxConnections),
+			slog.String("account_status", account.Status))
+	}
+
+	return refined
+}
+
 // slateVariant picks the codec variant to render the error slate in.
 //
 // When the origin failed before any codec was detected -- the common case, since
@@ -535,7 +578,7 @@ func (s *RelaySession) serveErrorSlate(cause error) (recovered bool, err error) 
 		return false, errors.New("no ES buffer to inject a slate into")
 	}
 
-	streamErr := ClassifyStreamError(cause)
+	streamErr := s.explainWithAccount(ClassifyStreamError(cause))
 	s.slateErr.Store(streamErr)
 
 	variant := s.slateVariant()

--- a/internal/relay/session.go
+++ b/internal/relay/session.go
@@ -2760,6 +2760,26 @@ func (s *RelaySession) IngestCompleted() bool {
 // Note: We only consider active transcoders as "active content", not buffer data alone.
 // If ingest is complete and all transcoders are stopped, buffer data is stale and the
 // session should be cleaned up even if the buffer still has bytes.
+// shouldRetainForDraining reports whether running transcoders should keep a
+// session with no clients alive.
+//
+// Only while the origin has finished. That is what this exemption was for --
+// letting a finite stream finish transcoding after the last client left -- but
+// it was applied to any running transcoder, and a live origin never finishes.
+// Such a session was therefore immortal: no clients, no grace period, cleanup
+// skipping it on every pass, and its upstream connection held open forever.
+//
+// That is not merely untidy. The provider allows a fixed number of concurrent
+// connections, so each abandoned session permanently consumes one, and once they
+// are used up every new stream is refused with "Too Many Connections" while
+// nobody is watching anything.
+//
+// Buffer contents alone never count: data with no transcoder and no client is
+// stale by definition.
+func (s *RelaySession) shouldRetainForDraining(activeTranscoders int) bool {
+	return activeTranscoders > 0 && s.IngestCompleted()
+}
+
 func (s *RelaySession) HasActiveContent() bool {
 	// Check for active (non-closed) transcoders
 	s.esTranscodersMu.RLock()
@@ -2779,10 +2799,7 @@ func (s *RelaySession) HasActiveContent() bool {
 		bufferBytes = stats.TotalBytes
 	}
 
-	// Only active transcoders count as active content.
-	// Buffer data alone (without active transcoders) is considered stale
-	// and the session can be cleaned up.
-	hasActive := activeTranscoders > 0
+	hasActive := s.shouldRetainForDraining(activeTranscoders)
 
 	slog.Debug("HasActiveContent check",
 		slog.String("session_id", s.ID.String()),

--- a/internal/relay/xtream_account.go
+++ b/internal/relay/xtream_account.go
@@ -1,0 +1,251 @@
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// XtreamAccount is the subset of an Xtream panel's user_info that says
+// something useful about why a stream might be refused.
+type XtreamAccount struct {
+	Auth           int
+	Status         string
+	ActiveCons     int
+	MaxConnections int
+	Expires        time.Time
+}
+
+// flexInt reads a field that a panel may send as either a JSON number or a
+// quoted string. Real responses mix the two in one object: auth arrives as 1
+// while active_cons alongside it arrives as "0".
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		*f = 0
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("not an integer: %s", s)
+	}
+	*f = flexInt(n)
+	return nil
+}
+
+type xtreamUserInfoEnvelope struct {
+	UserInfo struct {
+		Auth           flexInt `json:"auth"`
+		Status         string  `json:"status"`
+		ActiveCons     flexInt `json:"active_cons"`
+		MaxConnections flexInt `json:"max_connections"`
+		ExpDate        string  `json:"exp_date"`
+	} `json:"user_info"`
+}
+
+// Expired reports whether the subscription's end date has passed.
+func (a *XtreamAccount) Expired() bool {
+	return !a.Expires.IsZero() && time.Now().After(a.Expires)
+}
+
+// Authorised reports whether the panel accepts the credentials.
+func (a *XtreamAccount) Authorised() bool {
+	return a.Auth == 1 && (a.Status == "" || strings.EqualFold(a.Status, "Active"))
+}
+
+// AtConnectionLimit reports whether every permitted connection is in use.
+func (a *XtreamAccount) AtConnectionLimit() bool {
+	return a.MaxConnections > 0 && a.ActiveCons >= a.MaxConnections
+}
+
+// Refine returns a StreamError describing what the account itself reports,
+// falling back to the original when the account explains nothing.
+//
+// Nothing here guesses. The refusal codes an Xtream panel returns on the
+// streaming endpoint carry no reliable meaning -- the same URL answers 555, then
+// 999, and 666 elsewhere, all with empty bodies -- so the only trustworthy
+// account state is the one the panel publishes through player_api.php. Asking it
+// turns "the provider said 999" into "your subscription expired on the 9th".
+func (a *XtreamAccount) Refine(se *StreamError) *StreamError {
+	if a == nil || se == nil {
+		return se
+	}
+
+	switch {
+	case !a.Authorised():
+		status := a.Status
+		if status == "" {
+			status = "credentials rejected"
+		}
+		return &StreamError{
+			Kind:       StreamErrorUnavailable,
+			Headline:   "Check Credentials",
+			Detail:     fmt.Sprintf("Provider reports the account as %s.", status),
+			HTTPStatus: se.HTTPStatus,
+			Err:        se.Err,
+		}
+
+	case a.Expired():
+		return &StreamError{
+			Kind:       StreamErrorEnded,
+			Headline:   "Subscription Expired",
+			Detail:     fmt.Sprintf("This subscription ended on %s.", a.Expires.Format("2 January 2006")),
+			HTTPStatus: se.HTTPStatus,
+			Err:        se.Err,
+		}
+
+	case a.AtConnectionLimit():
+		return &StreamError{
+			Kind:     StreamErrorLimitReached,
+			Headline: "All Connections In Use",
+			Detail: fmt.Sprintf("This subscription allows %d stream(s) at once and %d are in use.",
+				a.MaxConnections, a.ActiveCons),
+			HTTPStatus: se.HTTPStatus,
+			Err:        se.Err,
+		}
+	}
+
+	// The account looks healthy, so the refusal is unexplained. Say only what was
+	// observed rather than inventing a reason for it.
+	return se
+}
+
+// ParseXtreamStreamURL pulls the panel base URL and credentials out of a stream
+// URL of the form scheme://host/live/USER/PASS/ID.ts.
+//
+// Taken from the stream URL rather than the source configuration because that is
+// what the request which actually failed used, so a stale credential baked into
+// a channel during an earlier ingestion is checked as-is instead of being masked
+// by newer settings.
+func ParseXtreamStreamURL(streamURL string) (base, username, password string, ok bool) {
+	u, err := url.Parse(streamURL)
+	if err != nil || u.Host == "" {
+		return "", "", "", false
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// Either /live/user/pass/id.ts or the extensionless /user/pass/id.
+	switch {
+	case len(parts) >= 4:
+		username, password = parts[len(parts)-3], parts[len(parts)-2]
+	case len(parts) == 3:
+		username, password = parts[0], parts[1]
+	default:
+		return "", "", "", false
+	}
+
+	if username == "" || password == "" {
+		return "", "", "", false
+	}
+
+	return u.Scheme + "://" + u.Host, username, password, true
+}
+
+// accountCacheTTL bounds how often one panel is asked about an account.
+//
+// A failing source tends to fail for every channel at once, so without this a
+// viewer flipping channels would fire a lookup per attempt at a provider that is
+// already refusing us and may well be rate limiting.
+const accountCacheTTL = 60 * time.Second
+
+type cachedAccount struct {
+	account *XtreamAccount
+	err     error
+	fetched time.Time
+}
+
+// AccountProber looks up Xtream account state, cached per credential pair.
+type AccountProber struct {
+	client *http.Client
+	logger *slog.Logger
+
+	mu    sync.Mutex
+	cache map[string]cachedAccount
+}
+
+// NewAccountProber creates a prober.
+func NewAccountProber(client *http.Client, logger *slog.Logger) *AccountProber {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AccountProber{
+		client: client,
+		logger: logger,
+		cache:  make(map[string]cachedAccount),
+	}
+}
+
+// Account returns the panel's view of the account behind a stream URL.
+func (p *AccountProber) Account(ctx context.Context, streamURL string) (*XtreamAccount, error) {
+	base, username, password, ok := ParseXtreamStreamURL(streamURL)
+	if !ok {
+		return nil, fmt.Errorf("not an Xtream stream URL: %s", streamURL)
+	}
+
+	key := base + "\x00" + username + "\x00" + password
+
+	p.mu.Lock()
+	if c, hit := p.cache[key]; hit && time.Since(c.fetched) < accountCacheTTL {
+		p.mu.Unlock()
+		return c.account, c.err
+	}
+	p.mu.Unlock()
+
+	account, err := p.fetch(ctx, base, username, password)
+
+	p.mu.Lock()
+	p.cache[key] = cachedAccount{account: account, err: err, fetched: time.Now()}
+	p.mu.Unlock()
+
+	return account, err
+}
+
+// fetch performs the player_api.php lookup.
+func (p *AccountProber) fetch(ctx context.Context, base, username, password string) (*XtreamAccount, error) {
+	endpoint := fmt.Sprintf("%s/player_api.php?username=%s&password=%s",
+		base, url.QueryEscape(username), url.QueryEscape(password))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building account request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("querying account: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("account lookup returned HTTP %d", resp.StatusCode)
+	}
+
+	var env xtreamUserInfoEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, fmt.Errorf("decoding account: %w", err)
+	}
+
+	account := &XtreamAccount{
+		Auth:           int(env.UserInfo.Auth),
+		Status:         env.UserInfo.Status,
+		ActiveCons:     int(env.UserInfo.ActiveCons),
+		MaxConnections: int(env.UserInfo.MaxConnections),
+	}
+	if secs, err := strconv.ParseInt(env.UserInfo.ExpDate, 10, 64); err == nil && secs > 0 {
+		account.Expires = time.Unix(secs, 0)
+	}
+
+	return account, nil
+}

--- a/internal/relay/xtream_account_test.go
+++ b/internal/relay/xtream_account_test.go
@@ -1,0 +1,153 @@
+package relay
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParseXtreamStreamURL(t *testing.T) {
+	tests := []struct {
+		name                     string
+		url                      string
+		base, username, password string
+		ok                       bool
+	}{
+		{"live path", "http://host.example/live/USER/PASS/451.ts", "http://host.example", "USER", "PASS", true},
+		{"extensionless", "http://host.example/USER/PASS/451", "http://host.example", "USER", "PASS", true},
+		{"with port", "http://host.example:8080/live/U/P/1.ts", "http://host.example:8080", "U", "P", true},
+		{"https", "https://host.example/live/U/P/1.m3u8", "https://host.example", "U", "P", true},
+		{"too short", "http://host.example/1.ts", "", "", "", false},
+		{"not a url", "://nonsense", "", "", "", false},
+		{"empty credential", "http://host.example/live//PASS/1.ts", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, user, pass, ok := ParseXtreamStreamURL(tt.url)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if base != tt.base || user != tt.username || pass != tt.password {
+				t.Errorf("got (%q,%q,%q), want (%q,%q,%q)", base, user, pass, tt.base, tt.username, tt.password)
+			}
+		})
+	}
+}
+
+// TestXtreamAccountRefine covers the whole point of asking the panel: turning an
+// opaque refusal into something the viewer can act on, and staying quiet when
+// the account explains nothing.
+func TestXtreamAccountRefine(t *testing.T) {
+	refused := NewUpstreamStatusError(999)
+
+	tests := []struct {
+		name     string
+		account  *XtreamAccount
+		headline string
+		kind     StreamErrorKind
+	}{
+		{
+			name:     "credentials rejected",
+			account:  &XtreamAccount{Auth: 0, Status: "Active", MaxConnections: 1},
+			headline: "Check Credentials",
+			kind:     StreamErrorUnavailable,
+		},
+		{
+			name:     "account disabled",
+			account:  &XtreamAccount{Auth: 1, Status: "Disabled", MaxConnections: 1},
+			headline: "Check Credentials",
+			kind:     StreamErrorUnavailable,
+		},
+		{
+			name:     "subscription expired",
+			account:  &XtreamAccount{Auth: 1, Status: "Active", MaxConnections: 1, Expires: time.Now().Add(-24 * time.Hour)},
+			headline: "Subscription Expired",
+			kind:     StreamErrorEnded,
+		},
+		{
+			name:     "every connection in use",
+			account:  &XtreamAccount{Auth: 1, Status: "Active", ActiveCons: 1, MaxConnections: 1, Expires: time.Now().Add(48 * time.Hour)},
+			headline: "All Connections In Use",
+			kind:     StreamErrorLimitReached,
+		},
+		{
+			// Exactly the state observed live while every stream was refused.
+			// The account explains nothing, so the slate must not invent a cause.
+			name:     "healthy account, unexplained refusal",
+			account:  &XtreamAccount{Auth: 1, Status: "Active", ActiveCons: 0, MaxConnections: 1, Expires: time.Now().Add(48 * time.Hour)},
+			headline: refused.Headline,
+			kind:     refused.Kind,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.account.Refine(refused)
+			if got.Headline != tt.headline {
+				t.Errorf("Headline = %q, want %q", got.Headline, tt.headline)
+			}
+			if got.Kind != tt.kind {
+				t.Errorf("Kind = %q, want %q", got.Kind, tt.kind)
+			}
+			if got.HTTPStatus != refused.HTTPStatus {
+				t.Errorf("lost the observed status: %d", got.HTTPStatus)
+			}
+		})
+	}
+
+	t.Run("nil account leaves the error alone", func(t *testing.T) {
+		var a *XtreamAccount
+		if got := a.Refine(refused); got != refused {
+			t.Errorf("nil account altered the error: %+v", got)
+		}
+	})
+}
+
+// TestAccountProberCaches guards the provider from a lookup per failed channel.
+// A source that refuses one stream usually refuses all of them, and the panel
+// may well be rate limiting already.
+func TestAccountProberCaches(t *testing.T) {
+	var calls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		// Mixed string/number typing, exactly as real panels reply.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"user_info":{"auth":1,"status":"Active","active_cons":"0","max_connections":"1","exp_date":"1788980041"}}`))
+	}))
+	defer srv.Close()
+
+	p := NewAccountProber(srv.Client(), nil)
+	streamURL := srv.URL + "/live/USER/PASS/451.ts"
+
+	for range 5 {
+		account, err := p.Account(context.Background(), streamURL)
+		if err != nil {
+			t.Fatalf("Account() failed: %v", err)
+		}
+		if account.Auth != 1 || account.MaxConnections != 1 || account.ActiveCons != 0 {
+			t.Fatalf("decoded wrongly: %+v", account)
+		}
+		if account.Expires.IsZero() {
+			t.Error("exp_date was not decoded")
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("panel queried %d times for 5 failures; the cache is not working", got)
+	}
+}
+
+func TestAccountProberRejectsNonXtreamURL(t *testing.T) {
+	p := NewAccountProber(nil, nil)
+	if _, err := p.Account(context.Background(), "http://example.com/playlist.m3u8"); err == nil {
+		t.Error("expected an error for a URL with no embedded credentials")
+	}
+}


### PR DESCRIPTION
Two fixes found while testing the slate on the cluster.

## 1. The slate rendered unreadably

It reached a real client and the headline and detail line were drawn through each other.

`drawScaledText` takes `y` as the TOP of a block, but the surrounding offsets were fixed multiples of the type scale, unrelated to the height of the text being drawn. At 720p the headline was 48px tall and drawn at the vertical centre (360→408) while the detail began at centre+30 = 390. An 18px overlap.

Every offset now derives from the measured line height of the face drawing it, and the rule, headline and wrapped detail stack as one vertically centred block. Geometry is returned separately from the drawing so it can be asserted: tests check no two elements overlap and none escapes the raster, across 640x360 → 3840x2160, including an empty detail and one long enough to wrap. **The previous layout fails these tests.** Also verified by rendering to PNG.

## 2. A live session with no clients never died

`HasActiveContent()` exempted any session with a running transcoder from cleanup. That exemption exists so a finite stream can finish transcoding after its last client leaves — but it was applied to *every* running transcoder, and a live origin never finishes. Such a session was immortal: no clients, the idle grace period never reached, cleanup skipping it on every pass, and its upstream connection held open.

That leaks provider capacity. The account allows a fixed number of concurrent connections, so each abandoned session permanently consumes one, and once they are gone every new stream is refused with "Too Many Connections" while nobody is watching anything.

Gated on `IngestCompleted()`, so the exemption applies to what it was written for — a finished origin still draining — and a live session with no clients is cleaned up like any other.

`go build`, `vet`, `gofmt`, full suite and `golangci-lint` (0 issues) all pass.