### PR TITLE
fix(epg): stop a stalled provider wedging EPG ingestion, and guard :latest

### DIFF
--- a/.github/workflows/docker-tvarr.yml
+++ b/.github/workflows/docker-tvarr.yml
@@ -223,7 +223,13 @@ jobs:
 
       # Note: Currently amd64 only - ARM64 support pending FFmpeg base image
 
+      # Guarded on main: :latest is what deployments track, so publishing it from
+      # a feature branch puts unreviewed code into production. The preview step
+      # below already had this condition; this one did not, so any non-PR run of
+      # this job -- a workflow_dispatch on a branch, for instance -- could
+      # overwrite :latest.
       - name: Create and push manifest (latest)
+        if: needs.gate.outputs.ref == 'main' || needs.gate.outputs.ref == 'refs/heads/main'
         run: |
           docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest 2>/dev/null || true
           docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \

--- a/internal/service/epg_service.go
+++ b/internal/service/epg_service.go
@@ -13,6 +13,13 @@ import (
 	"github.com/jmylchreest/tvarr/internal/service/progress"
 )
 
+// epgIngestionTimeout bounds one EPG ingestion run.
+//
+// Generous, because a large feed over a slow link legitimately takes a while,
+// but finite: without it a provider that stops responding mid-download wedges
+// the source forever.
+const epgIngestionTimeout = 2 * time.Hour
+
 // epgProgramSweepTimeout bounds a background program sweep. Generous, because
 // it is deleting millions of rows in batches behind a shared write lock, but
 // finite so a wedged sweep cannot hold resources for the process's lifetime.
@@ -366,16 +373,16 @@ func (s *EpgService) Ingest(ctx context.Context, id models.ULID) error {
 		progressMgr.SetMessage("Downloading programs...")
 	}
 
-	// Acquire type-level write lock to prevent concurrent EPG ingestions from
-	// writing to the epg_programs table simultaneously (prevents SQLite BUSY errors).
-	// Lock is acquired BEFORE writes begin (not before download).
-	s.logger.Debug("acquiring EPG write lock", "source_id", id.String())
-	epgWriteMutex.Lock()
-	s.logger.Debug("EPG write lock acquired", "source_id", id.String())
-	defer func() {
-		epgWriteMutex.Unlock()
-		s.logger.Debug("EPG write lock released", "source_id", id.String())
-	}()
+	// Programs are written under epgWriteMutex, which serialises concurrent EPG
+	// ingestions against the epg_programs table and keeps SQLite from returning
+	// BUSY. Only the writes take it.
+	//
+	// It used to be held here, around the whole of handler.Ingest -- the
+	// download. The comment claimed otherwise; the code did not match it. One
+	// source whose provider stopped responding therefore held the lock against
+	// every other EPG source indefinitely, and since the only logging around it
+	// was at Debug level, the queue behind it was invisible.
+	writeBatch := s.epgBatchWriter(ctx, id)
 
 	// Perform ingestion - download, parse, and upsert programs in batches.
 	// Using upsert (CreateBatch with ON CONFLICT DO UPDATE) allows us to:
@@ -400,7 +407,7 @@ func (s *EpgService) Ingest(ctx context.Context, id models.ULID) error {
 
 		// Flush batch when full (uses upsert, not insert)
 		if len(batchPrograms) >= batchSize {
-			if err := s.epgProgramRepo.CreateBatch(ctx, batchPrograms); err != nil {
+			if err := writeBatch(batchPrograms); err != nil {
 				return fmt.Errorf("batch upsert: %w", err)
 			}
 			batchPrograms = batchPrograms[:0]
@@ -418,7 +425,7 @@ func (s *EpgService) Ingest(ctx context.Context, id models.ULID) error {
 
 	// Flush any remaining programs
 	if len(batchPrograms) > 0 {
-		if batchErr := s.epgProgramRepo.CreateBatch(ctx, batchPrograms); batchErr != nil {
+		if batchErr := writeBatch(batchPrograms); batchErr != nil {
 			if err == nil {
 				err = fmt.Errorf("final batch upsert: %w", batchErr)
 			}
@@ -499,13 +506,43 @@ func (s *EpgService) IngestAsync(ctx context.Context, id models.ULID) error {
 		return fmt.Errorf("starting state tracking: %w", err)
 	}
 
-	// Run ingestion in background
+	// Run ingestion in background.
+	//
+	// Bounded, because it was previously started on a context.Background() with
+	// no deadline: a provider that accepts the connection and then stops
+	// responding left the ingestion blocked for the lifetime of the process,
+	// the source stuck reporting "ingesting", and no way back short of a
+	// restart.
 	go func() {
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithTimeout(context.Background(), epgIngestionTimeout)
+		defer cancel()
 		s.performIngestion(bgCtx, source)
 	}()
 
 	return nil
+}
+
+// epgBatchWriter returns a function that upserts a batch of programs while
+// holding the EPG write lock, reporting any wait long enough to be worth
+// knowing about.
+func (s *EpgService) epgBatchWriter(ctx context.Context, id models.ULID) func([]*models.EpgProgram) error {
+	return func(programs []*models.EpgProgram) error {
+		if len(programs) == 0 {
+			return nil
+		}
+
+		waited := time.Now()
+		epgWriteMutex.Lock()
+		defer epgWriteMutex.Unlock()
+
+		if blocked := time.Since(waited); blocked > time.Second {
+			s.logger.Info("waited for the EPG write lock",
+				"source_id", id.String(),
+				"waited", blocked)
+		}
+
+		return s.epgProgramRepo.CreateBatch(ctx, programs)
+	}
 }
 
 // performIngestion performs the actual EPG ingestion work.
@@ -567,16 +604,16 @@ func (s *EpgService) performIngestion(ctx context.Context, source *models.EpgSou
 		progressMgr.SetMessage("Downloading EPG data...")
 	}
 
-	// Acquire type-level write lock to prevent concurrent EPG ingestions from
-	// writing to the epg_programs table simultaneously (prevents SQLite BUSY errors).
-	// Lock is acquired BEFORE writes begin (not before download).
-	s.logger.Debug("acquiring EPG write lock", "source_id", id.String())
-	epgWriteMutex.Lock()
-	s.logger.Debug("EPG write lock acquired", "source_id", id.String())
-	defer func() {
-		epgWriteMutex.Unlock()
-		s.logger.Debug("EPG write lock released", "source_id", id.String())
-	}()
+	// Programs are written under epgWriteMutex, which serialises concurrent EPG
+	// ingestions against the epg_programs table and keeps SQLite from returning
+	// BUSY. Only the writes take it.
+	//
+	// It used to be held here, around the whole of handler.Ingest -- the
+	// download. The comment claimed otherwise; the code did not match it. One
+	// source whose provider stopped responding therefore held the lock against
+	// every other EPG source indefinitely, and since the only logging around it
+	// was at Debug level, the queue behind it was invisible.
+	writeBatch := s.epgBatchWriter(ctx, id)
 
 	// Perform ingestion - download, parse, and upsert programs in batches.
 	// Using upsert (CreateBatch with ON CONFLICT DO UPDATE) allows us to:
@@ -599,7 +636,7 @@ func (s *EpgService) performIngestion(ctx context.Context, source *models.EpgSou
 		}
 
 		if len(batchPrograms) >= batchSize {
-			if err := s.epgProgramRepo.CreateBatch(ctx, batchPrograms); err != nil {
+			if err := writeBatch(batchPrograms); err != nil {
 				return fmt.Errorf("batch upsert: %w", err)
 			}
 			batchPrograms = batchPrograms[:0]
@@ -617,7 +654,7 @@ func (s *EpgService) performIngestion(ctx context.Context, source *models.EpgSou
 
 	// Flush any remaining programs
 	if len(batchPrograms) > 0 {
-		if batchErr := s.epgProgramRepo.CreateBatch(ctx, batchPrograms); batchErr != nil {
+		if batchErr := writeBatch(batchPrograms); batchErr != nil {
 			if err == nil {
 				err = fmt.Errorf("final batch upsert: %w", batchErr)
 			}

--- a/internal/service/epg_service_test.go
+++ b/internal/service/epg_service_test.go
@@ -897,3 +897,57 @@ func TestEpgService_DeleteRemovesProgramsBeforeTheSourceRow(t *testing.T) {
 		return err == nil && len(pending) == 0 && programRepo.countPrograms() == 0
 	}, 5*time.Second, 10*time.Millisecond, "deletion did not complete in the background")
 }
+
+// TestEpgBatchWriterHoldsLockOnlyForTheWrite is the regression test for an
+// ingestion that wedged the whole subsystem.
+//
+// epgWriteMutex was held across handler.Ingest -- the network download -- so a
+// provider that accepted the connection and then stopped responding kept the
+// lock for the lifetime of the process, and every other EPG source queued behind
+// it forever. The lock must cover the database write and nothing else.
+func TestEpgBatchWriterHoldsLockOnlyForTheWrite(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	write := service.epgBatchWriter(context.Background(), models.NewULID())
+
+	// While no write is in flight the lock must be free, however long a
+	// notional download is taking.
+	if !epgWriteMutex.TryLock() {
+		t.Fatal("EPG write lock is held outside a write; a stalled download would block every other source")
+	}
+	epgWriteMutex.Unlock()
+
+	// And it still serialises actual writes.
+	require.NoError(t, write([]*models.EpgProgram{{
+		SourceID:  models.NewULID(),
+		ChannelID: "ch1",
+		Title:     "Programme",
+		Start:     time.Now(),
+		Stop:      time.Now().Add(time.Hour),
+	}}))
+
+	if got := programRepo.countPrograms(); got != 1 {
+		t.Errorf("programs written = %d, want 1", got)
+	}
+
+	// An empty batch must not touch the database or the lock.
+	require.NoError(t, write(nil))
+	if got := programRepo.countPrograms(); got != 1 {
+		t.Errorf("empty batch wrote something: %d programs", got)
+	}
+}
+
+// TestEpgIngestionTimeoutIsBounded guards the deadline itself. The background
+// ingestion previously ran on context.Background(), so a hung provider wedged
+// the source until the process restarted.
+func TestEpgIngestionTimeoutIsBounded(t *testing.T) {
+	if epgIngestionTimeout <= 0 {
+		t.Fatal("EPG ingestion has no deadline; a hung provider will wedge the source forever")
+	}
+	if epgIngestionTimeout > 6*time.Hour {
+		t.Errorf("EPG ingestion deadline of %v is long enough to outlast the 6-hourly schedule", epgIngestionTimeout)
+	}
+}


### PR DESCRIPTION
Two problems found while investigating an EPG source stuck reporting `ingesting` for hours with no activity at all.

## 1. EPG ingestion could wedge permanently

Three faults compounded:

**No deadline.** The background ingestion ran on `context.Background()`. A provider that accepts the connection then stops responding blocked it for the lifetime of the process. Now bounded at 2h — long enough for a large feed on a slow link, shorter than the 6-hourly schedule that queues the next attempt.

**A global lock held across the network download.** `epgWriteMutex` was taken around the whole of `handler.Ingest`, in *both* the synchronous and background paths. The comment above it claimed:

> "Lock is acquired BEFORE writes begin (not before download)."

which is exactly what the code did not do. One unresponsive source held a package-level mutex against every other EPG source indefinitely. Writes now take it and nothing else.

**The wait was invisible.** The only logging around the lock was `Debug`, so a source blocked behind it produced silence. A wait over a second is now logged at `Info` with its duration.

## 2. `:latest` was published from any branch

| step | guard (before) |
|---|---|
| push `:latest` — what deployments track | **none** |
| push `:preview` | `ref == 'main'` |

The intent was inverted. Any non-PR run of the manifest job — a `workflow_dispatch` on a branch, for instance — could overwrite `:latest`, and keel deploys it within the hour under `policy: force`. Now guarded on main, matching `:preview`.

## Tests

- The write lock must be free while no write is in flight (via `TryLock`), which fails if the lock is ever reinstated around the download.
- Empty batches touch neither the database nor the lock.
- The ingestion deadline exists and is shorter than the schedule interval.

`go build`, `vet`, `gofmt`, full suite and `golangci-lint` (0 issues) all pass.