### PR TITLE
fix(sources): cancel an in-flight ingestion when its source is edited

### DIFF
--- a/internal/service/epg_service.go
+++ b/internal/service/epg_service.go
@@ -27,6 +27,10 @@ const epgProgramSweepTimeout = 30 * time.Minute
 
 // EpgService provides business logic for EPG source management.
 type EpgService struct {
+	// ingests tracks in-flight ingestions so editing a source stops the run
+	// that is still using the old settings.
+	ingests ingestionCanceller
+
 	epgSourceRepo   repository.EpgSourceRepository
 	epgProgramRepo  repository.EpgProgramRepository
 	sourceRepo      repository.StreamSourceRepository
@@ -164,6 +168,14 @@ func (s *EpgService) tryAutoCreateStreamSource(ctx context.Context, epgSource *m
 func (s *EpgService) Update(ctx context.Context, source *models.EpgSource) error {
 	if err := source.Validate(); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	// An ingestion keeps using the source it loaded when it started, so one
+	// already running would carry on against the old settings and then write its
+	// stale copy back over this edit. Stop it.
+	if s.ingests.cancel(source.ID) {
+		s.logger.Info("cancelled in-flight EPG ingestion because the source was updated",
+			"id", source.ID.String())
 	}
 
 	if err := s.epgSourceRepo.Update(ctx, source); err != nil {
@@ -437,8 +449,7 @@ func (s *EpgService) Ingest(ctx context.Context, id models.ULID) error {
 			progressMgr.Fail(err)
 		}
 		s.stateManager.Fail(id, err)
-		source.MarkFailed(err)
-		_ = s.epgSourceRepo.Update(ctx, source)
+		s.recordOutcome(ctx, id, func(fresh *models.EpgSource) { fresh.MarkFailed(err) })
 		s.logger.Error("EPG ingestion failed",
 			"source_id", id.String(),
 			"error", err,
@@ -464,13 +475,7 @@ func (s *EpgService) Ingest(ctx context.Context, id models.ULID) error {
 	}
 
 	// Mark success
-	source.MarkSuccess(programCount)
-	if err := s.epgSourceRepo.Update(ctx, source); err != nil {
-		s.logger.Error("failed to update EPG source status",
-			"source_id", id.String(),
-			"error", err,
-		)
-	}
+	s.recordOutcome(ctx, id, func(fresh *models.EpgSource) { fresh.MarkSuccess(programCount) })
 
 	s.stateManager.Complete(id, programCount)
 
@@ -516,10 +521,36 @@ func (s *EpgService) IngestAsync(ctx context.Context, id models.ULID) error {
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.Background(), epgIngestionTimeout)
 		defer cancel()
+
+		untrack := s.ingests.track(id, cancel)
+		defer untrack()
+
 		s.performIngestion(bgCtx, source)
 	}()
 
 	return nil
+}
+
+// recordOutcome writes an ingestion's result against the current stored source
+// rather than the copy the run started with.
+//
+// The repository saves whole rows, so writing back the loaded copy silently
+// reverted anything changed while the run was in progress -- a URL corrected
+// mid-ingestion was undone the moment the stale run finished.
+func (s *EpgService) recordOutcome(ctx context.Context, id models.ULID, apply func(*models.EpgSource)) {
+	fresh, err := s.epgSourceRepo.GetByID(ctx, id)
+	if err != nil || fresh == nil {
+		s.logger.Warn("could not load EPG source to record the ingestion outcome",
+			"id", id.String(), "error", err)
+		return
+	}
+
+	apply(fresh)
+
+	if err := s.epgSourceRepo.Update(ctx, fresh); err != nil {
+		s.logger.Warn("could not record the EPG ingestion outcome",
+			"id", id.String(), "error", err)
+	}
 }
 
 // epgBatchWriter returns a function that upserts a batch of programs while
@@ -666,8 +697,7 @@ func (s *EpgService) performIngestion(ctx context.Context, source *models.EpgSou
 			progressMgr.Fail(err)
 		}
 		s.stateManager.Fail(id, err)
-		source.MarkFailed(err)
-		_ = s.epgSourceRepo.Update(ctx, source)
+		s.recordOutcome(ctx, id, func(fresh *models.EpgSource) { fresh.MarkFailed(err) })
 		s.logger.Error("async EPG ingestion failed",
 			"source_id", id.String(),
 			"error", err,
@@ -690,8 +720,7 @@ func (s *EpgService) performIngestion(ctx context.Context, source *models.EpgSou
 		)
 	}
 
-	source.MarkSuccess(programCount)
-	_ = s.epgSourceRepo.Update(ctx, source)
+	s.recordOutcome(ctx, id, func(fresh *models.EpgSource) { fresh.MarkSuccess(programCount) })
 	s.stateManager.Complete(id, programCount)
 
 	// Complete progress tracking

--- a/internal/service/epg_service_test.go
+++ b/internal/service/epg_service_test.go
@@ -951,3 +951,74 @@ func TestEpgIngestionTimeoutIsBounded(t *testing.T) {
 		t.Errorf("EPG ingestion deadline of %v is long enough to outlast the 6-hourly schedule", epgIngestionTimeout)
 	}
 }
+
+// TestEpgUpdateCancelsInFlightIngestion covers the edit case that prompted this:
+// a run started against a dead provider kept using it, ignoring a corrected URL.
+func TestEpgUpdateCancelsInFlightIngestion(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	source := &models.EpgSource{
+		Name:    "Editable EPG",
+		Type:    models.EpgSourceTypeXMLTV,
+		URL:     "http://old.example/epg.xml",
+		Enabled: new(true),
+	}
+	require.NoError(t, service.Create(context.Background(), source))
+
+	// Stand in for an ingestion in flight against the old URL.
+	runCtx, cancel := context.WithCancel(context.Background())
+	untrack := service.ingests.track(source.ID, cancel)
+	defer untrack()
+
+	source.URL = "http://new.example/epg.xml"
+	require.NoError(t, service.Update(context.Background(), source))
+
+	select {
+	case <-runCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("updating the source left the ingestion running against the old URL")
+	}
+}
+
+// TestEpgRecordOutcomeDoesNotRevertConcurrentEdits is the regression test for
+// the lost update: the repository saves whole rows, so an ingestion writing back
+// the copy it loaded silently undid a URL corrected while it was running.
+func TestEpgRecordOutcomeDoesNotRevertConcurrentEdits(t *testing.T) {
+	sourceRepo := newMockEpgSourceRepo()
+	programRepo := newMockEpgProgramRepo()
+	service := NewEpgService(sourceRepo, programRepo,
+		ingestor.NewEpgHandlerFactory(), ingestor.NewStateManager())
+
+	source := &models.EpgSource{
+		Name:    "Edited Mid-Run",
+		Type:    models.EpgSourceTypeXMLTV,
+		URL:     "http://old.example/epg.xml",
+		Enabled: new(true),
+	}
+	require.NoError(t, service.Create(context.Background(), source))
+
+	// The ingestion holds this copy, taken before the edit.
+	stale := *source
+
+	// Meanwhile the user corrects the URL.
+	updated := *source
+	updated.URL = "http://new.example/epg.xml"
+	require.NoError(t, service.Update(context.Background(), &updated))
+
+	// The stale run now finishes and records its result.
+	service.recordOutcome(context.Background(), stale.ID, func(fresh *models.EpgSource) {
+		fresh.MarkSuccess(1234)
+	})
+
+	got, err := service.GetByID(context.Background(), source.ID)
+	require.NoError(t, err)
+	if got.URL != "http://new.example/epg.xml" {
+		t.Errorf("URL = %q; the finishing ingestion reverted the edit", got.URL)
+	}
+	if got.ProgramCount != 1234 {
+		t.Errorf("ProgramCount = %d, want 1234 - the outcome was not recorded", got.ProgramCount)
+	}
+}

--- a/internal/service/ingestion_cancel.go
+++ b/internal/service/ingestion_cancel.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	"github.com/jmylchreest/tvarr/internal/models"
+)
+
+// ingestionCanceller tracks in-flight ingestions so a source edit can stop one.
+//
+// An ingestion loads its source once at the start and keeps using that copy, so
+// editing a source mid-run has no effect on it: a run started against a dead
+// provider keeps talking to the dead provider for as long as it takes to fail,
+// however many times the URL is corrected in the meantime. Worse, when it
+// finally ends it writes its stale copy back over the edit.
+//
+// Cancelling on update makes the edit mean what the user intended -- stop using
+// the old settings -- and lets a fresh run pick the new ones up.
+type ingestionCanceller struct {
+	mu      sync.Mutex
+	cancels map[models.ULID]*ingestionRun
+}
+
+// ingestionRun identifies one run, so a finishing run only ever deregisters
+// itself and never a newer one that has replaced it.
+type ingestionRun struct {
+	cancel context.CancelFunc
+}
+
+// track registers an in-flight ingestion and returns a function that
+// deregisters it, for the caller to defer.
+//
+// Any ingestion already running for the source is cancelled first: two runs
+// writing the same rows is never what is wanted.
+func (c *ingestionCanceller) track(id models.ULID, cancel context.CancelFunc) func() {
+	run := &ingestionRun{cancel: cancel}
+
+	c.mu.Lock()
+	if c.cancels == nil {
+		c.cancels = make(map[models.ULID]*ingestionRun)
+	}
+	if previous, running := c.cancels[id]; running {
+		previous.cancel()
+	}
+	c.cancels[id] = run
+	c.mu.Unlock()
+
+	return func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		// Only our own entry: a later run may already have replaced it.
+		if c.cancels[id] == run {
+			delete(c.cancels, id)
+		}
+	}
+}
+
+// cancel stops the ingestion running for a source, reporting whether there was
+// one.
+func (c *ingestionCanceller) cancel(id models.ULID) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	run, running := c.cancels[id]
+	if !running {
+		return false
+	}
+	run.cancel()
+	delete(c.cancels, id)
+	return true
+}
+
+// running reports whether an ingestion is in flight for a source.
+func (c *ingestionCanceller) running(id models.ULID) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.cancels[id]
+	return ok
+}

--- a/internal/service/ingestion_cancel_test.go
+++ b/internal/service/ingestion_cancel_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmylchreest/tvarr/internal/models"
+)
+
+// TestIngestionCancellerCancelsInFlightRun covers the behaviour a source edit
+// depends on: a run started against the old settings must actually stop.
+func TestIngestionCancellerCancelsInFlightRun(t *testing.T) {
+	var c ingestionCanceller
+	id := models.NewULID()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	untrack := c.track(id, cancel)
+	defer untrack()
+
+	if !c.running(id) {
+		t.Fatal("a tracked run is not reported as running")
+	}
+
+	if !c.cancel(id) {
+		t.Fatal("cancel() did not find the in-flight run")
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the run's context was not cancelled; it would keep using the old settings")
+	}
+
+	if c.running(id) {
+		t.Error("a cancelled run is still reported as running")
+	}
+}
+
+func TestIngestionCancellerIgnoresUnknownSource(t *testing.T) {
+	var c ingestionCanceller
+	if c.cancel(models.NewULID()) {
+		t.Error("cancel() claimed to stop a run that was never started")
+	}
+}
+
+// TestIngestionCancellerStartingAgainStopsThePrevious guards against two runs
+// writing the same rows at once.
+func TestIngestionCancellerStartingAgainStopsThePrevious(t *testing.T) {
+	var c ingestionCanceller
+	id := models.NewULID()
+
+	firstCtx, firstCancel := context.WithCancel(context.Background())
+	defer c.track(id, firstCancel)()
+
+	secondCtx, secondCancel := context.WithCancel(context.Background())
+	defer c.track(id, secondCancel)()
+
+	select {
+	case <-firstCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("starting a second run did not stop the first")
+	}
+
+	if secondCtx.Err() != nil {
+		t.Error("the second run was cancelled by its own registration")
+	}
+}
+
+// TestIngestionCancellerUntrackLeavesNewerRunAlone: a slow run finishing must
+// not deregister the run that replaced it, or that one becomes uncancellable.
+func TestIngestionCancellerUntrackLeavesNewerRunAlone(t *testing.T) {
+	var c ingestionCanceller
+	id := models.NewULID()
+
+	_, oldCancel := context.WithCancel(context.Background())
+	untrackOld := c.track(id, oldCancel)
+
+	newCtx, newCancel := context.WithCancel(context.Background())
+	untrackNew := c.track(id, newCancel)
+	defer untrackNew()
+
+	// The superseded run finishes and tidies up after itself.
+	untrackOld()
+
+	if !c.running(id) {
+		t.Fatal("the newer run was deregistered by an older one finishing")
+	}
+	if !c.cancel(id) {
+		t.Fatal("the newer run could no longer be cancelled")
+	}
+	if newCtx.Err() == nil {
+		t.Error("cancelling did not reach the newer run")
+	}
+}

--- a/internal/service/source_service.go
+++ b/internal/service/source_service.go
@@ -93,6 +93,10 @@ func (c *DefaultEPGChecker) CheckEPGAvailability(ctx context.Context, baseURL, u
 
 // SourceService provides business logic for stream source management.
 type SourceService struct {
+	// ingests tracks in-flight ingestions so editing a source stops the run
+	// that is still using the old settings.
+	ingests ingestionCanceller
+
 	sourceRepo      repository.StreamSourceRepository
 	channelRepo     repository.ChannelRepository
 	epgSourceRepo   repository.EpgSourceRepository
@@ -257,6 +261,14 @@ func (s *SourceService) Update(ctx context.Context, source *models.StreamSource)
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	// An ingestion keeps using the source it loaded when it started, so one
+	// already running would carry on against the old settings and then write its
+	// stale copy back over this edit. Stop it.
+	if s.ingests.cancel(source.ID) {
+		s.logger.Info("cancelled in-flight stream ingestion because the source was updated",
+			"id", source.ID.String())
+	}
+
 	if err := s.sourceRepo.Update(ctx, source); err != nil {
 		return fmt.Errorf("updating source: %w", err)
 	}
@@ -418,8 +430,7 @@ func (s *SourceService) Ingest(ctx context.Context, id models.ULID) error {
 			progressMgr.Fail(err)
 		}
 		s.stateManager.Fail(id, err)
-		source.MarkFailed(err)
-		_ = s.sourceRepo.Update(ctx, source)
+		s.recordOutcome(ctx, id, func(fresh *models.StreamSource) { fresh.MarkFailed(err) })
 		return fmt.Errorf("ingesting channels: %w", err)
 	}
 
@@ -473,13 +484,7 @@ func (s *SourceService) Ingest(ctx context.Context, id models.ULID) error {
 	}
 
 	// Mark success
-	source.MarkSuccess(channelCount)
-	if err := s.sourceRepo.Update(ctx, source); err != nil {
-		s.logger.Error("failed to update source status",
-			"source_id", id.String(),
-			"error", err,
-		)
-	}
+	s.recordOutcome(ctx, id, func(fresh *models.StreamSource) { fresh.MarkSuccess(channelCount) })
 
 	s.stateManager.Complete(id, channelCount)
 
@@ -527,19 +532,51 @@ func (s *SourceService) IngestAsync(ctx context.Context, id models.ULID) error {
 		return fmt.Errorf("starting state tracking: %w", err)
 	}
 
-	// Run ingestion in background
+	// Run ingestion in background.
+	//
+	// Bounded and cancellable: on a context.Background() a provider that stops
+	// responding blocked the run for the lifetime of the process, and nothing
+	// could stop a run that was using settings the user had since corrected.
 	go func() {
 		// Ensure we release the lock when done
 		defer s.ingestionLocks.Delete(id)
 
-		// Create a new context that isn't tied to the request
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithTimeout(context.Background(), streamIngestionTimeout)
+		defer cancel()
+
+		untrack := s.ingests.track(id, cancel)
+		defer untrack()
 
 		// Perform the actual ingestion (state already started)
 		s.performIngestion(bgCtx, source)
 	}()
 
 	return nil
+}
+
+// streamIngestionTimeout bounds one stream source ingestion run.
+const streamIngestionTimeout = 2 * time.Hour
+
+// recordOutcome writes an ingestion's result against the current stored source
+// rather than the copy the run started with.
+//
+// The repository saves whole rows, so writing back the loaded copy silently
+// reverted anything changed while the run was in progress -- a URL corrected
+// mid-ingestion was undone the moment the stale run finished.
+func (s *SourceService) recordOutcome(ctx context.Context, id models.ULID, apply func(*models.StreamSource)) {
+	fresh, err := s.sourceRepo.GetByID(ctx, id)
+	if err != nil || fresh == nil {
+		s.logger.Warn("could not load stream source to record the ingestion outcome",
+			"id", id.String(), "error", err)
+		return
+	}
+
+	apply(fresh)
+
+	if err := s.sourceRepo.Update(ctx, fresh); err != nil {
+		s.logger.Warn("could not record the stream ingestion outcome",
+			"id", id.String(), "error", err)
+	}
 }
 
 // performIngestion performs the actual ingestion work.
@@ -676,8 +713,7 @@ func (s *SourceService) performIngestion(ctx context.Context, source *models.Str
 			progressMgr.Fail(err)
 		}
 		s.stateManager.Fail(id, err)
-		source.MarkFailed(err)
-		_ = s.sourceRepo.Update(ctx, source)
+		s.recordOutcome(ctx, id, func(fresh *models.StreamSource) { fresh.MarkFailed(err) })
 		s.logger.Error("async ingestion failed",
 			"source_id", id.String(),
 			"error", err,


### PR DESCRIPTION
Found while correcting an EPG source URL during a stalled ingestion.

## Two faults, both in stream *and* EPG sources

**Editing a source did nothing to a run already using it.** An ingestion loads its source once and keeps that copy for the whole run. A run started against a dead provider kept talking to the dead provider no matter how many times the URL was corrected.

**And the finishing run reverted the edit.** `Update` is a GORM `Save()` — a whole-row write. The ingestion ended with `source.MarkSuccess(n)` on the copy it loaded, then saved it, silently undoing anything changed while it ran. So the edit appeared to take, then reverted itself minutes later when a run nobody could see finished.

## Fix

- Editing a source cancels any ingestion still using the old settings.
- Ingestions record their outcome against the *stored* source rather than their loaded copy, leaving concurrent edits intact.
- Stream ingestion gains the same deadline EPG ingestion got earlier — it was also running on `context.Background()`.

The canceller identifies **runs**, not sources, so a superseded run tidying up after itself cannot deregister the run that replaced it and leave that one uncancellable.

## Tests

- Cancelling reaches an in-flight run; unknown sources are a no-op.
- Starting a second run stops the first.
- A superseded run finishing leaves the newer run tracked and still cancellable.
- Updating an EPG source cancels the run against the old URL.
- A stale run recording success does **not** revert a URL edited mid-run, while still recording the programme count.

`go build`, `vet`, `gofmt`, full suite and `golangci-lint` (0 issues) all pass.